### PR TITLE
Add support for the MADT

### DIFF
--- a/src/aml/mod.rs
+++ b/src/aml/mod.rs
@@ -42,18 +42,18 @@ impl AmlTable {
     }
 }
 
-pub(crate) fn parse_aml_table<'a, 'h, H>(
-    acpi: &'a mut Acpi<'h, H>,
+pub(crate) fn parse_aml_table<H>(
+    acpi: &mut Acpi,
+    handler: &mut H,
     mapping: &PhysicalMapping<AmlTable>,
     signature: &[u8; 4],
 ) -> Result<(), AcpiError>
 where
-    'h: 'a,
-    H: AcpiHandler + 'a,
+    H: AcpiHandler,
 {
     (*mapping).header.validate(signature)?;
 
-    match AmlParser::parse(acpi, "\\", (*mapping).stream()) {
+    match AmlParser::parse(acpi, handler, "\\", (*mapping).stream()) {
         Ok(_) => Ok(()),
         Err(error) => Err(AcpiError::InvalidAmlTable(*signature, error)),
     }

--- a/src/aml/parser.rs
+++ b/src/aml/parser.rs
@@ -24,10 +24,10 @@ struct PkgLength {
 
 pub(crate) struct AmlParser<'s, 'a, 'h, H>
 where
-    'h: 'a,
     H: AcpiHandler + 'h,
 {
-    acpi: &'a mut Acpi<'h, H>,
+    acpi: &'a mut Acpi,
+    handler: &'h mut H,
     scope: String,
     stream: AmlStream<'s>,
 }
@@ -48,16 +48,17 @@ macro_rules! try_parse {
 
 impl<'s, 'a, 'h, H> AmlParser<'s, 'a, 'h, H>
 where
-    'h: 'a,
-    H: AcpiHandler + 'h,
+    H: AcpiHandler,
 {
     pub(crate) fn parse(
-        acpi: &'a mut Acpi<'h, H>,
+        acpi: &'a mut Acpi,
+        handler: &'h mut H,
         scope: &str,
         stream: AmlStream<'s>,
     ) -> Result<(), AmlError> {
         let mut parser = AmlParser {
             acpi,
+            handler,
             scope: String::from(scope),
             stream,
         };

--- a/src/fadt.rs
+++ b/src/fadt.rs
@@ -92,7 +92,8 @@ where
 
     // Parse the DSDT
     let dsdt_header = sdt::peek_at_sdt_header(handler, dsdt_physical_address);
-    let dsdt_mapping = handler.map_physical_region::<AmlTable>(dsdt_physical_address, dsdt_header.length() as usize);
+    let dsdt_mapping = handler
+        .map_physical_region::<AmlTable>(dsdt_physical_address, dsdt_header.length() as usize);
     if let Err(error) = parse_aml_table(acpi, handler, &dsdt_mapping, b"DSDT") {
         error!("Failed to parse DSDT: {:?}. At this stage, this is expected, but should be fatal in the future", error);
     }

--- a/src/fadt.rs
+++ b/src/fadt.rs
@@ -74,13 +74,13 @@ pub struct Fadt {
     hypervisor_vendor_id: u64,
 }
 
-pub(crate) fn parse_fadt<'a, 'h, H>(
-    acpi: &'a mut Acpi<'h, H>,
+pub(crate) fn parse_fadt<H>(
+    acpi: &mut Acpi,
+    handler: &mut H,
     mapping: &PhysicalMapping<Fadt>,
 ) -> Result<(), AcpiError>
 where
-    'h: 'a,
-    H: AcpiHandler + 'a,
+    H: AcpiHandler,
 {
     (*mapping).header.validate(b"FACP")?;
 
@@ -91,14 +91,12 @@ where
     };
 
     // Parse the DSDT
-    let dsdt_header = sdt::peek_at_sdt_header(acpi.handler, dsdt_physical_address);
-    let dsdt_mapping = acpi
-        .handler
-        .map_physical_region::<AmlTable>(dsdt_physical_address, dsdt_header.length() as usize);
-    if let Err(error) = parse_aml_table(acpi, &dsdt_mapping, b"DSDT") {
+    let dsdt_header = sdt::peek_at_sdt_header(handler, dsdt_physical_address);
+    let dsdt_mapping = handler.map_physical_region::<AmlTable>(dsdt_physical_address, dsdt_header.length() as usize);
+    if let Err(error) = parse_aml_table(acpi, handler, &dsdt_mapping, b"DSDT") {
         error!("Failed to parse DSDT: {:?}. At this stage, this is expected, but should be fatal in the future", error);
     }
-    acpi.handler.unmap_physical_region(dsdt_mapping);
+    handler.unmap_physical_region(dsdt_mapping);
 
     Ok(())
 }

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -14,6 +14,41 @@ pub enum LocalInterruptLine {
 }
 
 #[derive(Debug)]
+pub enum Polarity {
+    SameAsBus,
+    ActiveHigh,
+    ActiveLow,
+}
+
+#[derive(Debug)]
+pub enum TriggerMode {
+    SameAsBus,
+    Edge,
+    Level,
+}
+
+/// Describes a difference in the mapping of an ISA interrupt to how it's mapped in other interrupt
+/// models. For example, if a device is connected to ISA IRQ 0 and IOAPIC input 2, an override will
+/// appear mapping source 0 to GSI 2. Currently these will only be created for ISA interrupt
+/// sources.
+#[derive(Debug)]
+pub struct InterruptSourceOverride {
+    pub isa_source: u8,
+    pub global_system_interrupt: u32,
+    pub polarity: Polarity,
+    pub trigger_mode: TriggerMode,
+}
+
+/// Describes a Global System Interrupt that should be enabled as non-maskable. Any source that is
+/// non-maskable can not be used by devices.
+#[derive(Debug)]
+pub struct NmiSource {
+    pub global_system_interrupt: u32,
+    pub polarity: Polarity,
+    pub trigger_mode: TriggerMode,
+}
+
+#[derive(Debug)]
 pub enum InterruptModel {
     /// This model is only chosen when a newer one can not be found and the system supports the
     /// legacy dual-8259 PIC.
@@ -26,6 +61,8 @@ pub enum InterruptModel {
         local_apic_address: u64,
         io_apics: Vec<IoApic>,
         local_apic_nmi_line: LocalInterruptLine,
+        interrupt_source_overrides: Vec<InterruptSourceOverride>,
+        nmi_sources: Vec<NmiSource>,
 
         /// If this field is set, you must remap and mask all the lines of the legacy PIC, even if
         /// you choose to use the APIC. It's recommended that you do this even if ACPI does not

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -1,0 +1,35 @@
+use alloc::vec::Vec;
+
+#[derive(Debug)]
+pub struct IoApic {
+    pub id: u8,
+    pub address: u32,
+    pub global_system_interrupt_base: u32,
+}
+
+#[derive(Debug)]
+pub enum LocalInterruptLine {
+    Lint0,
+    Lint1,
+}
+
+#[derive(Debug)]
+pub enum InterruptModel {
+    /// This model is only chosen when a newer one can not be found and the system supports the
+    /// legacy dual-8259 PIC.
+    Pic,
+
+    /// Describes an interrupt controller based around the Advanced Programmable Interrupt
+    /// Controllers. These are likely to be found on x86 and x86_64 systems and are made up of a
+    /// Local APIC for each core and one or more I/O APICs to handle external interrupts.
+    Apic {
+        local_apic_address: u64,
+        io_apics: Vec<IoApic>,
+        local_apic_nmi_line: LocalInterruptLine,
+
+        /// If this field is set, you must remap and mask all the lines of the legacy PIC, even if
+        /// you choose to use the APIC. It's recommended that you do this even if ACPI does not
+        /// require you to.
+        also_has_legacy_pics: bool,
+    },
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate bit_field;
 mod aml;
 mod fadt;
 mod hpet;
+mod madt;
 mod rsdp;
 mod rsdp_search;
 mod sdt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ mod sdt;
 
 pub use rsdp_search::search_for_rsdp_bios;
 
-use alloc::{collections::BTreeMap, vec::Vec, string::String};
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
 use aml::{AmlError, AmlValue};
 use core::mem;
 use core::ops::Deref;
@@ -142,8 +142,7 @@ pub trait AcpiHandler {
 }
 
 #[derive(Debug)]
-pub struct Acpi
-{
+pub struct Acpi {
     acpi_revision: u8,
     namespace: BTreeMap<String, AmlValue>,
     boot_processor: Option<Processor>,
@@ -238,7 +237,8 @@ where
     };
 
     let header = sdt::peek_at_sdt_header(handler, physical_address);
-    let mapping = handler.map_physical_region::<SdtHeader>(physical_address, header.length() as usize);
+    let mapping =
+        handler.map_physical_region::<SdtHeader>(physical_address, header.length() as usize);
 
     if revision == 0 {
         /*
@@ -252,8 +252,11 @@ where
             ((mapping.virtual_start.as_ptr() as usize) + mem::size_of::<SdtHeader>()) as *const u32;
 
         for i in 0..num_tables {
-            sdt::dispatch_sdt(&mut acpi, handler, unsafe { *tables_base.offset(i as isize) }
-                as usize)?;
+            sdt::dispatch_sdt(
+                &mut acpi,
+                handler,
+                unsafe { *tables_base.offset(i as isize) } as usize,
+            )?;
         }
     } else {
         /*
@@ -267,8 +270,11 @@ where
             ((mapping.virtual_start.as_ptr() as usize) + mem::size_of::<SdtHeader>()) as *const u64;
 
         for i in 0..num_tables {
-            sdt::dispatch_sdt(&mut acpi, handler, unsafe { *tables_base.offset(i as isize) }
-                as usize)?;
+            sdt::dispatch_sdt(
+                &mut acpi,
+                handler,
+                unsafe { *tables_base.offset(i as isize) } as usize,
+            )?;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(nll)]
 #![feature(alloc)]
 #![feature(exclusive_range_pattern, range_contains)]
+#![feature(exhaustive_integer_patterns)]
 
 #[cfg(test)]
 #[macro_use]
@@ -21,10 +22,12 @@ mod rsdp;
 mod rsdp_search;
 mod sdt;
 
+pub use aml::AmlError;
+pub use madt::MadtError;
 pub use rsdp_search::search_for_rsdp_bios;
 
 use alloc::{collections::BTreeMap, string::String, vec::Vec};
-use aml::{AmlError, AmlValue};
+use aml::AmlValue;
 use core::mem;
 use core::ops::Deref;
 use core::ptr::NonNull;
@@ -47,7 +50,7 @@ pub enum AcpiError {
 
     InvalidAmlTable([u8; 4], AmlError),
 
-    MalformedMadt(&'static str),
+    InvalidMadt(MadtError),
 }
 
 #[repr(C, packed)]

--- a/src/madt.rs
+++ b/src/madt.rs
@@ -1,0 +1,382 @@
+use core::marker::PhantomData;
+use core::mem;
+use sdt::SdtHeader;
+use {Acpi, AcpiError, AcpiHandler, PhysicalMapping};
+
+/// Represents the MADT - this contains the MADT header fields. You can then iterate over a `Madt`
+/// to read each entry from it.
+#[repr(C, packed)]
+pub(crate) struct Madt {
+    header: SdtHeader,
+    local_apic_address: u32,
+    flags: u32,
+}
+
+impl Madt {
+    fn entries(&self) -> MadtEntryIter {
+        MadtEntryIter {
+            pointer: unsafe {
+                (self as *const Madt as *const u8).offset(mem::size_of::<Madt>() as isize)
+            },
+            remaining_length: self.header.length() - mem::size_of::<Madt>() as u32,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+struct MadtEntryIter<'a> {
+    pointer: *const u8,
+    remaining_length: u32,
+    _phantom: PhantomData<&'a u8>,
+}
+
+enum MadtEntry<'a> {
+    LocalApic(&'a LocalApicEntry),
+    IoApic(&'a IoApicEntry),
+    InterruptSourceOverride(&'a InterruptSourceOverrideEntry),
+    NmiSource(&'a NmiSourceEntry),
+    LocalApicNmi(&'a LocalApicNmiEntry),
+    LocalApicAddressOverride(&'a LocalApicAddressOverrideEntry),
+    IoSapic(&'a IoSapicEntry),
+    LocalSapic(&'a LocalSapicEntry),
+    PlatformInterruptSource(&'a PlatformInterruptSourceEntry),
+    LocalX2Apic(&'a LocalX2ApicEntry),
+    X2ApicNmi(&'a X2ApicNmiEntry),
+    Gicc(&'a GiccEntry),
+    Gicd(&'a GicdEntry),
+    GicMsiFrame(&'a GicMsiFrameEntry),
+    GicRedistributor(&'a GicRedistributorEntry),
+    GicInterruptTranslationService(&'a GicInterruptTranslationServiceEntry),
+}
+
+impl<'a> Iterator for MadtEntryIter<'a> {
+    type Item = MadtEntry<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.remaining_length > 0 {
+            let entry_pointer = self.pointer;
+            let header = unsafe { *(self.pointer as *const EntryHeader) };
+
+            self.pointer = unsafe { self.pointer.offset(header.length as isize) };
+            self.remaining_length -= header.length as u32;
+            info!(
+                "Found MADT entry of {} bytes (id={}), {} bytes remaining",
+                header.length, header.entry_type, self.remaining_length
+            );
+
+            match header.entry_type {
+                0x0 => {
+                    return Some(MadtEntry::LocalApic(unsafe {
+                        &*(entry_pointer as *const LocalApicEntry)
+                    }))
+                }
+
+                0x1 => {
+                    return Some(MadtEntry::IoApic(unsafe {
+                        &*(entry_pointer as *const IoApicEntry)
+                    }))
+                }
+
+                0x2 => {
+                    return Some(MadtEntry::InterruptSourceOverride(unsafe {
+                        &*(entry_pointer as *const InterruptSourceOverrideEntry)
+                    }))
+                }
+
+                0x3 => {
+                    return Some(MadtEntry::NmiSource(unsafe {
+                        &*(entry_pointer as *const NmiSourceEntry)
+                    }))
+                }
+
+                0x4 => {
+                    return Some(MadtEntry::LocalApicNmi(unsafe {
+                        &*(entry_pointer as *const LocalApicNmiEntry)
+                    }))
+                }
+
+                0x5 => {
+                    return Some(MadtEntry::LocalApicAddressOverride(unsafe {
+                        &*(entry_pointer as *const LocalApicAddressOverrideEntry)
+                    }))
+                }
+
+                0x6 => {
+                    return Some(MadtEntry::IoSapic(unsafe {
+                        &*(entry_pointer as *const IoSapicEntry)
+                    }))
+                }
+
+                0x7 => {
+                    return Some(MadtEntry::LocalSapic(unsafe {
+                        &*(entry_pointer as *const LocalSapicEntry)
+                    }))
+                }
+
+                0x8 => {
+                    return Some(MadtEntry::PlatformInterruptSource(unsafe {
+                        &*(entry_pointer as *const PlatformInterruptSourceEntry)
+                    }))
+                }
+
+                0x9 => {
+                    return Some(MadtEntry::LocalX2Apic(unsafe {
+                        &*(entry_pointer as *const LocalX2ApicEntry)
+                    }))
+                }
+
+                0xa => {
+                    return Some(MadtEntry::X2ApicNmi(unsafe {
+                        &*(entry_pointer as *const X2ApicNmiEntry)
+                    }))
+                }
+
+                0xb => {
+                    return Some(MadtEntry::Gicc(unsafe {
+                        &*(entry_pointer as *const GiccEntry)
+                    }))
+                }
+
+                0xc => {
+                    return Some(MadtEntry::Gicd(unsafe {
+                        &*(entry_pointer as *const GicdEntry)
+                    }))
+                }
+
+                0xd => {
+                    return Some(MadtEntry::GicMsiFrame(unsafe {
+                        &*(entry_pointer as *const GicMsiFrameEntry)
+                    }))
+                }
+
+                0xe => {
+                    return Some(MadtEntry::GicRedistributor(unsafe {
+                        &*(entry_pointer as *const GicRedistributorEntry)
+                    }))
+                }
+
+                0xf => {
+                    return Some(MadtEntry::GicInterruptTranslationService(unsafe {
+                        &*(entry_pointer as *const GicInterruptTranslationServiceEntry)
+                    }))
+                }
+
+                /*
+                 * These entry types are reserved by the ACPI standard. We should skip them if they
+                 * appear in a real MADT.
+                 */
+                0x10..0x7f => {}
+
+                /*
+                 * These entry types are reserved for OEM use. Atm, we just skip them too.
+                 * TODO: work out if we should ever do anything else here
+                 */
+                0x80..0xff => {}
+
+                // TODO: remove when support for exhaustive integer patterns is merged
+                _ => unreachable!(),
+            }
+        }
+
+        None
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+struct EntryHeader {
+    entry_type: u8,
+    length: u8,
+}
+
+#[repr(C, packed)]
+struct LocalApicEntry {
+    header: EntryHeader,
+    processor_id: u8,
+    apic_id: u8,
+    flags: u32,
+}
+
+#[repr(C, packed)]
+struct IoApicEntry {
+    header: EntryHeader,
+    io_apic_id: u8,
+    _reserved: u8,
+    io_apic_address: u32,
+    global_system_interrupt_base: u32,
+}
+
+#[repr(C, packed)]
+struct InterruptSourceOverrideEntry {
+    header: EntryHeader,
+    bus: u8, // 0 - ISA bus
+    irq: u8, // This is bus-relative
+    global_system_interrupt: u32,
+    flags: u16,
+}
+
+#[repr(C, packed)]
+struct NmiSourceEntry {
+    header: EntryHeader,
+    flags: u16,
+    global_system_interrupt: u32,
+}
+
+#[repr(C, packed)]
+struct LocalApicNmiEntry {
+    header: EntryHeader,
+    processor_id: u8,
+    flags: u16,
+    nmi_line: u8, // Describes which LINTn is the NMI connected to
+}
+
+#[repr(C, packed)]
+struct LocalApicAddressOverrideEntry {
+    header: EntryHeader,
+    _reserved: u16,
+    local_apic_address: u64,
+}
+
+/// If this entry is present, the system has an I/O SAPIC, which must be used instead of the I/O APIC.
+#[repr(C, packed)]
+struct IoSapicEntry {
+    header: EntryHeader,
+    io_apic_id: u8,
+    _reserved: u8,
+    global_system_interrupt_base: u32,
+    io_sapic_address: u64,
+}
+
+#[repr(C, packed)]
+struct LocalSapicEntry {
+    header: EntryHeader,
+    processor_id: u8,
+    local_sapic_id: u8,
+    local_sapic_eid: u8,
+    _reserved: [u8; 3],
+    flags: u32,
+    processor_uid: u32,
+
+    /// This string can be used to associate this local SAPIC to a processor defined in the
+    /// namespace when the `_UID` object is a string. It is a null-terminated ASCII string, and so
+    /// this field will be `'\0'` if the string is not present, otherwise it extends from the
+    /// address of this field.
+    processor_uid_string: u8,
+}
+
+#[repr(C, packed)]
+struct PlatformInterruptSourceEntry {
+    header: EntryHeader,
+    flags: u16,
+    interrupt_type: u8,
+    processor_id: u8,
+    processor_eid: u8,
+    io_sapic_vector: u8,
+    global_system_interrupt: u32,
+    platform_interrupt_source_flags: u32,
+}
+
+#[repr(C, packed)]
+struct LocalX2ApicEntry {
+    header: EntryHeader,
+    _reserved: u16,
+    x2apic_id: u32,
+    flags: u32,
+    processor_uid: u32,
+}
+
+#[repr(C, packed)]
+struct X2ApicNmiEntry {
+    header: EntryHeader,
+    flags: u16,
+    processor_uid: u32,
+    nmi_line: u8,
+    _reserved: [u8; 3],
+}
+
+/// This field will appear for ARM processors that support ACPI and use the Generic Interrupt
+/// Controller. In the GICC interrupt model, each logical process has a Processor Device object in
+/// the namespace, and uses this structure to convey its GIC information.
+#[repr(C, packed)]
+struct GiccEntry {
+    header: EntryHeader,
+    _reserved1: u16,
+    cpu_interface_number: u32,
+    processor_uid: u32,
+    flags: u32,
+    parking_protocol_version: u32,
+    performance_interrupt_gsiv: u32,
+    parked_address: u64,
+    gic_registers_address: u64,
+    gic_control_block_address: u64,
+    vgic_maintenance_interrupt: u32,
+    gicr_base_address: u64,
+    mpidr: u64,
+    processor_power_efficiency_class: u8,
+    _reserved2: [u8; 3],
+}
+
+#[repr(C, packed)]
+struct GicdEntry {
+    header: EntryHeader,
+    _reserved1: u16,
+    gic_id: u32,
+    physical_base_address: u64,
+    system_vector_base: u32,
+
+    /// The GIC version
+    ///     0x00: Fall back to hardware discovery
+    ///     0x01: GICv1
+    ///     0x02: GICv2
+    ///     0x03: GICv3
+    ///     0x04: GICv4
+    ///     0x05-0xff: Reserved for future use
+    gic_version: u8,
+    _reserved2: [u8; 3],
+}
+
+#[repr(C, packed)]
+struct GicMsiFrameEntry {
+    header: EntryHeader,
+    _reserved: u16,
+    frame_id: u32,
+    physical_base_address: u64,
+    flags: u32,
+    spi_count: u16,
+    spi_base: u16,
+}
+
+#[repr(C, packed)]
+struct GicRedistributorEntry {
+    header: EntryHeader,
+    _reserved: u16,
+    discovery_range_base_address: u64,
+    discovery_range_length: u32,
+}
+
+#[repr(C, packed)]
+struct GicInterruptTranslationServiceEntry {
+    header: EntryHeader,
+    _reserved1: u16,
+    id: u32,
+    physical_base_address: u64,
+    _reserved2: u32,
+}
+
+pub(crate) fn parse_madt<'a, 'h, H>(
+    acpi: &'a mut Acpi<'h, H>,
+    mapping: &PhysicalMapping<Madt>,
+) -> Result<(), AcpiError>
+where
+    'h: 'a,
+    H: AcpiHandler + 'a,
+{
+    (*mapping).header.validate(b"APIC")?;
+
+    for entry in (*mapping).entries() {
+        info!("Found MADT entry");
+        // TODO: parse entries
+    }
+
+    Ok(())
+}

--- a/src/madt.rs
+++ b/src/madt.rs
@@ -2,7 +2,9 @@ use alloc::vec::Vec;
 use bit_field::BitField;
 use core::marker::PhantomData;
 use core::mem;
-use interrupt::{InterruptModel, IoApic, Polarity, TriggerMode, InterruptSourceOverride, NmiSource};
+use interrupt::{
+    InterruptModel, InterruptSourceOverride, IoApic, NmiSource, Polarity, TriggerMode,
+};
 use sdt::SdtHeader;
 use {Acpi, AcpiError, AcpiHandler, PhysicalMapping, Processor, ProcessorState};
 
@@ -461,12 +463,7 @@ fn parse_apic_model(
                     (false, false) => ProcessorState::Running,
                 };
 
-                let processor = Processor::new(
-                    entry.processor_id,
-                    entry.apic_id,
-                    state,
-                    is_ap,
-                );
+                let processor = Processor::new(entry.processor_id, entry.apic_id, state, is_ap);
 
                 if is_ap {
                     acpi.application_processors.push(processor);
@@ -485,7 +482,9 @@ fn parse_apic_model(
 
             MadtEntry::InterruptSourceOverride(ref entry) => {
                 if entry.bus != 0 {
-                    return Err(AcpiError::MalformedMadt("APIC: interrupt override on unsupported bus"));
+                    return Err(AcpiError::MalformedMadt(
+                        "APIC: interrupt override on unsupported bus",
+                    ));
                 }
 
                 let (polarity, trigger_mode) = parse_mps_inti_flags(entry.flags)?;
@@ -529,7 +528,9 @@ fn parse_apic_model(
     Ok(InterruptModel::Apic {
         local_apic_address,
         io_apics,
-        local_apic_nmi_line: local_apic_nmi_line.ok_or(AcpiError::MalformedMadt("APIC: no local NMI line specified"))?,
+        local_apic_nmi_line: local_apic_nmi_line.ok_or(AcpiError::MalformedMadt(
+            "APIC: no local NMI line specified",
+        ))?,
         interrupt_source_overrides,
         nmi_sources,
         also_has_legacy_pics: (*mapping).supports_8259(),

--- a/src/rsdp_search.rs
+++ b/src/rsdp_search.rs
@@ -1,6 +1,6 @@
 use core::{mem, ops::RangeInclusive};
-use Acpi;
 use rsdp::Rsdp;
+use Acpi;
 use {parse_validated_rsdp, AcpiError, AcpiHandler};
 
 /// The pointer to the EBDA (Extended Bios Data Area) start segment pointer

--- a/src/rsdp_search.rs
+++ b/src/rsdp_search.rs
@@ -1,4 +1,5 @@
 use core::{mem, ops::RangeInclusive};
+use Acpi;
 use rsdp::Rsdp;
 use {parse_validated_rsdp, AcpiError, AcpiHandler};
 
@@ -55,7 +56,7 @@ where
 ///
 /// This function is unsafe because it may read from protected memory if the computer is using UEFI.
 /// Only use this function if you are sure the computer is using BIOS.
-pub unsafe fn search_for_rsdp_bios<H>(handler: &mut H) -> Result<(), AcpiError>
+pub unsafe fn search_for_rsdp_bios<H>(handler: &mut H) -> Result<Acpi, AcpiError>
 where
     H: AcpiHandler,
 {

--- a/src/sdt.rs
+++ b/src/sdt.rs
@@ -177,19 +177,22 @@ where
      */
     match header.signature() {
         "FACP" => {
-            let fadt_mapping = handler.map_physical_region::<Fadt>(physical_address, mem::size_of::<Fadt>());
+            let fadt_mapping =
+                handler.map_physical_region::<Fadt>(physical_address, mem::size_of::<Fadt>());
             ::fadt::parse_fadt(acpi, handler, &fadt_mapping)?;
             handler.unmap_physical_region(fadt_mapping);
         }
 
         "HPET" => {
-            let hpet_mapping = handler.map_physical_region::<Hpet>(physical_address, mem::size_of::<Hpet>());
+            let hpet_mapping =
+                handler.map_physical_region::<Hpet>(physical_address, mem::size_of::<Hpet>());
             ::hpet::parse_hpet(&hpet_mapping)?;
             handler.unmap_physical_region(hpet_mapping);
         }
 
         "APIC" => {
-            let madt_mapping = handler.map_physical_region::<Madt>(physical_address, header.length() as usize);
+            let madt_mapping =
+                handler.map_physical_region::<Madt>(physical_address, header.length() as usize);
             ::madt::parse_madt(acpi, handler, &madt_mapping)?;
             handler.unmap_physical_region(madt_mapping);
         }

--- a/src/sdt.rs
+++ b/src/sdt.rs
@@ -1,6 +1,7 @@
 use core::{mem, str};
 use fadt::Fadt;
 use hpet::Hpet;
+use madt::Madt;
 use {Acpi, AcpiError, AcpiHandler};
 
 /// All SDTs share the same header, and are `length` bytes long. The signature tells us which SDT
@@ -189,6 +190,14 @@ where
                 .map_physical_region::<Hpet>(physical_address, mem::size_of::<Hpet>());
             ::hpet::parse_hpet(&hpet_mapping)?;
             acpi.handler.unmap_physical_region(hpet_mapping);
+        }
+
+        "APIC" => {
+            let madt_mapping = acpi
+                .handler
+                .map_physical_region::<Madt>(physical_address, header.length() as usize);
+            ::madt::parse_madt(acpi, &madt_mapping)?;
+            acpi.handler.unmap_physical_region(madt_mapping);
         }
 
         signature => {

--- a/src/sdt.rs
+++ b/src/sdt.rs
@@ -156,15 +156,15 @@ where
 
 /// This takes the physical address of an SDT, maps it correctly and dispatches it to whatever
 /// function parses that table.
-pub(crate) fn dispatch_sdt<'a, 'h, H>(
-    acpi: &'a mut Acpi<'h, H>,
+pub(crate) fn dispatch_sdt<H>(
+    acpi: &mut Acpi,
+    handler: &mut H,
     physical_address: usize,
 ) -> Result<(), AcpiError>
 where
-    'h: 'a,
-    H: AcpiHandler + 'a,
+    H: AcpiHandler,
 {
-    let header = peek_at_sdt_header(acpi.handler, physical_address);
+    let header = peek_at_sdt_header(handler, physical_address);
     info!(
         "Dispatching SDT with signature {:?} and length {:?}",
         header.signature(),
@@ -177,27 +177,21 @@ where
      */
     match header.signature() {
         "FACP" => {
-            let fadt_mapping = acpi
-                .handler
-                .map_physical_region::<Fadt>(physical_address, mem::size_of::<Fadt>());
-            ::fadt::parse_fadt(acpi, &fadt_mapping)?;
-            acpi.handler.unmap_physical_region(fadt_mapping);
+            let fadt_mapping = handler.map_physical_region::<Fadt>(physical_address, mem::size_of::<Fadt>());
+            ::fadt::parse_fadt(acpi, handler, &fadt_mapping)?;
+            handler.unmap_physical_region(fadt_mapping);
         }
 
         "HPET" => {
-            let hpet_mapping = acpi
-                .handler
-                .map_physical_region::<Hpet>(physical_address, mem::size_of::<Hpet>());
+            let hpet_mapping = handler.map_physical_region::<Hpet>(physical_address, mem::size_of::<Hpet>());
             ::hpet::parse_hpet(&hpet_mapping)?;
-            acpi.handler.unmap_physical_region(hpet_mapping);
+            handler.unmap_physical_region(hpet_mapping);
         }
 
         "APIC" => {
-            let madt_mapping = acpi
-                .handler
-                .map_physical_region::<Madt>(physical_address, header.length() as usize);
-            ::madt::parse_madt(acpi, &madt_mapping)?;
-            acpi.handler.unmap_physical_region(madt_mapping);
+            let madt_mapping = handler.map_physical_region::<Madt>(physical_address, header.length() as usize);
+            ::madt::parse_madt(acpi, handler, &madt_mapping)?;
+            handler.unmap_physical_region(madt_mapping);
         }
 
         signature => {


### PR DESCRIPTION
This starts adding support for the MADT

- [x] Add definitions for the structures of the header and entries
- [x] Add safe way to enumerate the entries
- [x] Decide how we're going to relay this information to the OSPM
- [x] Parse the entries and relay that information
- [x] Sanity check the entries? E.g. we don't expect a `IoApic` and a `GicMsiFrame` to appear in the same MADT
- [x] Fully parse information for the APIC model

Thank you to @Sh4d1 for his initial work on this!