### PR TITLE
Add RSDP manual search

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@ mod aml;
 mod fadt;
 mod hpet;
 mod rsdp;
-mod sdt;
 mod rsdp_search;
+mod sdt;
 
 use alloc::{collections::BTreeMap, string::String};
 use aml::{AmlError, AmlValue};
@@ -25,8 +25,8 @@ use core::mem;
 use core::ops::Deref;
 use core::ptr::NonNull;
 use rsdp::Rsdp;
-use sdt::SdtHeader;
 use rsdp_search::*;
+use sdt::SdtHeader;
 
 #[derive(Debug)]
 // TODO: manually implement Debug to print signatures correctly etc.
@@ -123,16 +123,14 @@ where
         // the in EBDA. Also, if we cannot find the EBDA, then we don't want to search the largest
         // possible EBDA first.
         RSDP_BIOS_AREA_START..=RSDP_BIOS_AREA_END,
-
         if let Some(ebda_start) = ebda_start {
             // First kb of EBDA
             ebda_start..=ebda_start + 1024
         } else {
             // We don't know where the EBDA starts, so just search the largest possible EBDA
             EBDA_EARLIEST_START..=EBDA_END
-        }
+        },
     ];
-
 
     // On x86 it is more efficient to map 4096 bytes at a time because of how paging works
     let mut area_mapping = handler.map_physical_region::<[[u8; 8]; 0x1000 / 8]>(
@@ -142,7 +140,6 @@ where
 
     // Signature is always on a 16 byte boundary so only search there
     for address in areas.iter().flat_map(|i| i.clone()).step_by(16) {
-
         let mut mapping_start = area_mapping.physical_start as usize;
         if !(mapping_start..mapping_start + 0x1000).contains(&address) {
             handler.unmap_physical_region(area_mapping);
@@ -173,7 +170,7 @@ where
             | Err(e @ AcpiError::RsdpInvalidChecksum) => {
                 warn!("Invalid RSDP found at 0x{:x}: {:?}", address, e);
                 continue;
-            },
+            }
             // TODO perhaps use a custom error type for the RSDP validation
             // (RsdpValidationError for example) to make this type safe
             Err(_) => unreachable!(),
@@ -201,10 +198,10 @@ where
 
 fn parse_validated_rsdp<H>(
     handler: &mut H,
-    rsdp_mapping: PhysicalMapping<Rsdp>
+    rsdp_mapping: PhysicalMapping<Rsdp>,
 ) -> Result<(), AcpiError>
-    where
-        H: AcpiHandler,
+where
+    H: AcpiHandler,
 {
     let revision = (*rsdp_mapping).revision();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![feature(nll)]
 #![feature(alloc)]
-#![feature(exclusive_range_pattern)]
+#![feature(exclusive_range_pattern, range_contains)]
 
 #[cfg(test)]
 #[macro_use]
@@ -22,7 +22,7 @@ use alloc::{collections::BTreeMap, string::String};
 use aml::{AmlError, AmlValue};
 use core::mem;
 use core::ops::Deref;
-use core::ptr::NonNull;
+use core::ptr::{self, NonNull};
 use rsdp::Rsdp;
 use sdt::SdtHeader;
 
@@ -32,6 +32,7 @@ pub enum AcpiError {
     RsdpIncorrectSignature,
     RsdpInvalidOemId,
     RsdpInvalidChecksum,
+    NoValidRsdp,
 
     SdtInvalidSignature([u8; 4]),
     SdtInvalidOemId([u8; 4]),
@@ -98,6 +99,93 @@ where
     acpi_revision: u8,
     namespace: BTreeMap<String, AmlValue>,
 }
+
+/// The pointer to the EBDA (Extended Bios Data Area) start segment pointer
+const EBDA_START_SEGMENT_PTR: usize = 0x40e;
+/// The earliest (lowest) memory address an EBDA (Extended Bios Data Area) can start
+const EBDA_EARLIEST_START: usize = 0x80000;
+/// The end of the EBDA (Extended Bios Data Area)
+const EBDA_END: usize = 0x9ffff;
+/// The start of the main bios area below 1mb in which to search for the RSDP
+/// (Root System Description Pointer)
+const RSDP_BIOS_AREA_START: usize = 0xe0000;
+/// The end of the main bios area below 1mb in which to search for the RSDP
+/// (Root System Description Pointer)
+const RSDP_BIOS_AREA_END: usize = 0xfffff;
+/// The RSDP (Root System Description Pointer)'s signature, "RSD PTR " (note trailing space)
+const RSDP_SIGNATURE: &'static [u8; 8] = b"RSD PTR ";
+
+/// Find the begining of the EBDA (Extended Bios Data Area) and return `None` if the ptr at
+/// `0x40e` is invalid.
+fn find_ebda_start() -> Option<usize> {
+    // Read base segment from BIOS area. This is not always given by the bios, so it needs to be
+    // checked. We left shift 4 because it is a segment.
+    let base = (unsafe { ptr::read(EBDA_START_SEGMENT_PTR as *const u16) } as usize) << 4;
+
+    // Check if base segment ptr is in valid range valid
+    if (EBDA_EARLIEST_START..EBDA_END).contains(&base) {
+        debug!("EBDA address is {:#x}", base);
+        Some(base)
+    } else {
+        warn!(
+            "EBDA address at {:#x} out of range ({:#x}), falling back to {:#x}",
+            EBDA_START_SEGMENT_PTR,
+            base,
+            EBDA_EARLIEST_START
+        );
+
+        None
+    }
+}
+
+/// This is the entry point of `acpi` if you have no information except that the machine is running
+/// BIOS and not UEFI. It maps the RSDP, works out what version of ACPI the hardware supports, and
+/// passes the physical address of the RSDT/XSDT to `parse_rsdt`.
+pub fn search_for_rsdp_bios<H>(handler: &mut H, rsdp_address: usize) -> Result<(), AcpiError>
+where
+    H: AcpiHandler,
+{
+    let ebda_start = find_ebda_start();
+
+    // The areas that will be searched for the RSDP
+    let areas = [
+        // Main bios area below 1 mb
+        // In practice (from my [Restioson's] testing, at least), the RSDP is more often here than
+        // the in EBDA
+        RSDP_BIOS_AREA_START..=RSDP_BIOS_AREA_END,
+
+        if let Some(ebda_start) = ebda_start {
+            // First kb of EBDA
+            ebda_start..=ebda_start + 1024
+        } else {
+            // We don't know where the EBDA starts, so just search the largest possible EBDA
+            EBDA_EARLIEST_START..=EBDA_END
+        }
+    ];
+
+    // Signature is always on a 16 byte boundary so only search there
+    for address in areas.into_iter().flat_map(|i| i.clone()).step_by(16) {
+        let signature: [u8; 8] = unsafe { ptr::read(address as *const _) };
+
+        if signature != *RSDP_SIGNATURE {
+            continue;
+        }
+
+        let parse_result = parse_rsdp(handler, address);
+
+        // This will need to be updated if any more RSDP errors are added (but I doubt more will)
+        match parse_result {
+            Ok(()) => return Ok(()),
+            Err(AcpiError::RsdpIncorrectSignature)
+            | Err(AcpiError::RsdpInvalidOemId)
+            | Err(AcpiError::RsdpInvalidChecksum) => warn!("Invalid RSDP found at {:?}", address),
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(AcpiError::NoValidRsdp)
+}
+
 
 /// This is the entry point of `acpi` if you have the **physical** address of the RSDP. It maps
 /// the RSDP, works out what version of ACPI the hardware supports, and passes the physical

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub trait AcpiHandler {
     /// a `T` (but may be bigger than `size_of::<T>()`). The address doesn't have to be page-aligned,
     /// so the implementation may have to add padding to either end. The given size must be greater
     /// or equal to the size of a `T`. The virtual address the memory is mapped to does not matter,
-    /// as long as it is accessibly by `acpi`.
+    /// as long as it is accessible from `acpi`.
     fn map_physical_region<T>(
         &mut self,
         physical_address: usize,

--- a/src/rsdp.rs
+++ b/src/rsdp.rs
@@ -124,7 +124,8 @@ mod tests {
                     - signature.iter().map(|&b| isize::from(b)).sum::<isize>()
                     - oem_id.iter().map(|&b| isize::from(b)).sum::<isize>()
                     - revision as isize
-                    - rsdt_address as isize) & 0b1111_1111) as u8,
+                    - rsdt_address as isize)
+                    & 0b1111_1111) as u8,
             );
 
             let ext_checksum = ext_checksum.unwrap_or(

--- a/src/rsdp_search.rs
+++ b/src/rsdp_search.rs
@@ -36,7 +36,6 @@ where
         // the in EBDA. Also, if we cannot find the EBDA, then we don't want to search the largest
         // possible EBDA first.
         RSDP_BIOS_AREA_START..=RSDP_BIOS_AREA_END,
-
         // Check if base segment ptr is in valid range for EBDA base
         if (EBDA_EARLIEST_START..EBDA_END).contains(&base) {
             // First kb of EBDA

--- a/src/rsdp_search.rs
+++ b/src/rsdp_search.rs
@@ -25,10 +25,10 @@ where
 {
     // Read base segment from BIOS area. This is not always given by the bios, so it needs to be
     // checked. We left shift 4 because it is a segment ptr.
-    let base_mapping =
+    let ebda_start_mapping =
         handler.map_physical_region::<u16>(EBDA_START_SEGMENT_PTR, mem::size_of::<u16>());
-    let base = (*base_mapping as usize) << 4;
-    handler.unmap_physical_region(base_mapping);
+    let ebda_start = (*ebda_start_mapping as usize) << 4;
+    handler.unmap_physical_region(ebda_start_mapping);
 
     [
         // Main bios area below 1 mb
@@ -37,9 +37,9 @@ where
         // possible EBDA first.
         RSDP_BIOS_AREA_START..=RSDP_BIOS_AREA_END,
         // Check if base segment ptr is in valid range for EBDA base
-        if (EBDA_EARLIEST_START..EBDA_END).contains(&base) {
+        if (EBDA_EARLIEST_START..EBDA_END).contains(&ebda_start) {
             // First kb of EBDA
-            base..=base + 1024
+            ebda_start..=ebda_start + 1024
         } else {
             // We don't know where the EBDA starts, so just search the largest possible EBDA
             EBDA_EARLIEST_START..=EBDA_END

--- a/src/rsdp_search.rs
+++ b/src/rsdp_search.rs
@@ -1,0 +1,47 @@
+use core::mem;
+use ::AcpiHandler;
+
+/// The pointer to the EBDA (Extended Bios Data Area) start segment pointer
+pub const EBDA_START_SEGMENT_PTR: usize = 0x40e;
+/// The earliest (lowest) memory address an EBDA (Extended Bios Data Area) can start
+pub const EBDA_EARLIEST_START: usize = 0x80000;
+/// The end of the EBDA (Extended Bios Data Area)
+pub const EBDA_END: usize = 0x9ffff;
+/// The start of the main bios area below 1mb in which to search for the RSDP
+/// (Root System Description Pointer)
+pub const RSDP_BIOS_AREA_START: usize = 0xe0000;
+/// The end of the main bios area below 1mb in which to search for the RSDP
+/// (Root System Description Pointer)
+pub const RSDP_BIOS_AREA_END: usize = 0xfffff;
+/// The RSDP (Root System Description Pointer)'s signature, "RSD PTR " (note trailing space)
+pub const RSDP_SIGNATURE: &'static [u8; 8] = b"RSD PTR ";
+
+/// Find the begining of the EBDA (Extended Bios Data Area) and return `None` if the ptr at
+/// `0x40e` is invalid.
+pub fn find_ebda_start<H>(handler: &mut H) -> Option<usize>
+    where
+        H: AcpiHandler,
+{
+    // Read base segment from BIOS area. This is not always given by the bios, so it needs to be
+    // checked. We left shift 4 because it is a segment ptr.
+    let base_mapping = handler.map_physical_region::<u16>(
+        EBDA_START_SEGMENT_PTR, mem::size_of::<u16>()
+    );
+    let base = (*base_mapping as usize) << 4;
+    handler.unmap_physical_region(base_mapping);
+
+    // Check if base segment ptr is in valid range valid
+    if (EBDA_EARLIEST_START..EBDA_END).contains(&base) {
+        debug!("EBDA address is {:#x}", base);
+        Some(base)
+    } else {
+        warn!(
+            "EBDA address at {:#x} out of range ({:#x}), falling back to {:#x}",
+            EBDA_START_SEGMENT_PTR,
+            base,
+            EBDA_EARLIEST_START
+        );
+
+        None
+    }
+}

--- a/src/rsdp_search.rs
+++ b/src/rsdp_search.rs
@@ -1,6 +1,6 @@
 use core::{mem, ops::RangeInclusive};
-use ::{AcpiHandler, AcpiError, parse_validated_rsdp};
 use rsdp::Rsdp;
+use {parse_validated_rsdp, AcpiError, AcpiHandler};
 
 /// The pointer to the EBDA (Extended Bios Data Area) start segment pointer
 const EBDA_START_SEGMENT_PTR: usize = 0x40e;
@@ -59,7 +59,6 @@ where
     ]
 }
 
-
 /// This is the entry point of `acpi` if you have no information except that the machine is running
 /// BIOS and not UEFI. It maps the RSDP, works out what version of ACPI the hardware supports, and
 /// passes the physical address of the RSDT/XSDT to `parse_rsdt`.
@@ -69,8 +68,8 @@ where
 /// This function is unsafe because it may read from protected memory if the computer is using UEFI.
 /// Only use this function if you are sure the computer is using BIOS.
 pub unsafe fn search_for_rsdp_bios<H>(handler: &mut H) -> Result<(), AcpiError>
-    where
-        H: AcpiHandler,
+where
+    H: AcpiHandler,
 {
     // The areas that will be searched for the RSDP
     let areas = find_search_areas(handler);

--- a/src/rsdp_search.rs
+++ b/src/rsdp_search.rs
@@ -1,5 +1,5 @@
 use core::mem;
-use ::AcpiHandler;
+use AcpiHandler;
 
 /// The pointer to the EBDA (Extended Bios Data Area) start segment pointer
 pub const EBDA_START_SEGMENT_PTR: usize = 0x40e;
@@ -19,14 +19,13 @@ pub const RSDP_SIGNATURE: &'static [u8; 8] = b"RSD PTR ";
 /// Find the begining of the EBDA (Extended Bios Data Area) and return `None` if the ptr at
 /// `0x40e` is invalid.
 pub fn find_ebda_start<H>(handler: &mut H) -> Option<usize>
-    where
-        H: AcpiHandler,
+where
+    H: AcpiHandler,
 {
     // Read base segment from BIOS area. This is not always given by the bios, so it needs to be
     // checked. We left shift 4 because it is a segment ptr.
-    let base_mapping = handler.map_physical_region::<u16>(
-        EBDA_START_SEGMENT_PTR, mem::size_of::<u16>()
-    );
+    let base_mapping =
+        handler.map_physical_region::<u16>(EBDA_START_SEGMENT_PTR, mem::size_of::<u16>());
     let base = (*base_mapping as usize) << 4;
     handler.unmap_physical_region(base_mapping);
 
@@ -37,9 +36,7 @@ pub fn find_ebda_start<H>(handler: &mut H) -> Option<usize>
     } else {
         warn!(
             "EBDA address at {:#x} out of range ({:#x}), falling back to {:#x}",
-            EBDA_START_SEGMENT_PTR,
-            base,
-            EBDA_EARLIEST_START
+            EBDA_START_SEGMENT_PTR, base, EBDA_EARLIEST_START
         );
 
         None


### PR DESCRIPTION
This adds a modified version of Flower's rsdp search (which works in qemu and on my lenovo laptop). It only works for bios machines (I believe UEFI gives you the location of the RSDP). It is untested as of yet, so please **do not merge it** (I will test it as soon as I can get flower's acpi crate branch working...).

It also appears that I have done something bad to the git history in my branch, so when it is merged please make sure to squash it.

TODO
- [x] Don't map/unmap repeatedly -- only when needed (i.e reuse where possible)
- [ ] Address review comments
- [x] Rustfmt