### PR TITLE
Add ExtendedField abstraction

### DIFF
--- a/acpi/Cargo.toml
+++ b/acpi/Cargo.toml
@@ -12,3 +12,4 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 bit_field = "0.9"
+typenum = "1"

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -34,6 +34,7 @@ extern crate std;
 extern crate log;
 extern crate alloc;
 extern crate bit_field;
+extern crate typenum;
 
 mod fadt;
 pub mod handler;


### PR DESCRIPTION
This makes accessing extended (and therefore only sometimes present) fields unsafe in the FADT. This abstraction is extendable to any other situations like this.