### PR TITLE
[WIP] Prepare for 0.2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acpi"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Isaac Woods <isaacwoods.home@gmail.com>"]
 repository = "https://github.com/rust-osdev/acpi"
 description = "Library for parsing ACPI tables and AML"
@@ -8,5 +8,5 @@ readme = "README.md"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-log = "0.*"
-bit_field = "0.9.0"
+log = "0.4"
+bit_field = "0.9"

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # Acpi
 [![Build Status](https://travis-ci.org/rust-osdev/acpi.svg?branch=master)](https://travis-ci.org/rust-osdev/acpi)
 [![Version](https://img.shields.io/crates/v/acpi.svg?style=rounded-square)](https://crates.io/crates/acpi/)
+[![Docs](https://docs.rs/acpi/badge.svg)](https://docs.rs/acpi)
 
 A library to parse ACPI tables and AML, written in Rust. Designed to be easy to use from inside a
 kernel written in Rust, and fully tested.
-**Acpi is currently very early in development, will be highly unstable and is next to useless for
-actually parsing ACPI or AML.**
 
-## Using
-`acpi` uses the nightly channel, and currently builds on `rustc 1.27.0-nightly (7925ff4e 2018-04-19)`.
-If `acpi` fails to build on a later nightly, please file an issue!
+Acpi is still far from feature-complete, but can be used to parse the static tables and so can be
+used to set up the APIC and HPET.
 
 ## Contributing
 Contributions are more than welcome! You can:
+- Request features and give feedback - the API is still in its infancy and we're flexible to
+supporting the needs of projects using the library.
 - Write code - the ACPI spec is huge and there are bound to be things we don't support yet!
+- Add documentation!
+- Test it! If you're writing a kernel and test on real hardware, we'd like to know about any discrepancies
+you find (many firmwares aren't compliant, and we'd like to deal with as many common issues as possible).
 
 ## Resources
 - [The ACPI specification](http://www.uefi.org/sites/default/files/resources/ACPI%206_2_A_Sept29.pdf)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,4 @@
+# 0.2.0
+First usable release. Can parse the MADT, FADT, and HPET static tables. This allows the library to be
+used to configure the APIC and HPET. The library doesn't yet have the ability to fully parse AML
+tables or execute methods defined in them.

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -1,3 +1,5 @@
+//! Describes the system's interrupt model.
+
 use alloc::vec::Vec;
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,19 +192,19 @@ pub struct Acpi {
 impl Acpi {
     /// A description of the boot processor. Until you bring any more up, this is the only processor
     /// running code, even on SMP systems.
-    pub fn boot_processor<'a>(&'a self) -> &'a Option<Processor> {
+    pub fn boot_processor(&self) -> &Option<Processor> {
         &self.boot_processor
     }
 
     /// Descriptions of each of the application processors. These are not brought up until you do
     /// so. The application processors must be brought up in the order that they appear in this
     /// list.
-    pub fn application_processors<'a>(&'a self) -> &'a Vec<Processor> {
+    pub fn application_processors(&self) -> &Vec<Processor> {
         &self.application_processors
     }
 
     /// The interrupt model supported by this system.
-    pub fn interrupt_model<'a>(&'a self) -> &'a Option<InterruptModel> {
+    pub fn interrupt_model(&self) -> &Option<InterruptModel> {
         &self.interrupt_model
     }
 }


### PR DESCRIPTION
Basically this library has fallen a little under my radar with my uni applications and what-not going on, and since the AML parser still needs quite a bit more work to be at all useful, I thought it'd be useful to get a version released with the progress that's been made so far. This should be useful for parsing the static tables and e.g. setting up the APIC or HPET.

- [ ] Make data gathered about HPET visible to the user
- [x] Add RELEASES.md entry
- [x] Rewrite README.md
- [x] Increment version
- [ ] Publish to crates.io
- [ ] Create tag

cc @rust-osdev/acpi in case anyone has any objections to any of these changes / making a release at this stage