### PR TITLE
AML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ before_script:
 
 script:
   - cargo fmt --all -- --check
-  - cargo build
-  - cargo test
+  - cargo build --all
+  - cargo test --all
 
 notifications:
   email: change

--- a/acpi/src/hpet.rs
+++ b/acpi/src/hpet.rs
@@ -43,7 +43,6 @@ pub(crate) fn parse_hpet(
     // Make sure the HPET's in system memory
     assert_eq!(hpet.base_address.address_space, 0);
 
-    info!("HPET address: {:#?}", hpet.base_address);
     acpi.hpet = Some(HpetInfo {
         event_timer_block_id: hpet.event_timer_block_id,
         base_address: hpet.base_address.address as usize,

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -13,10 +13,10 @@
 //! memory into the virtual address space.
 //!
 //! You should then call one of the entry points, based on how much information you have:
-//!     * Call `parse_rsdp` if you have the physical address of the RSDP
-//!     * Call `parse_rsdt` if you have the physical address of the RSDT / XSDT
-//!     * Call `search_for_rsdp_bios` if you don't have the address of either structure, but **you
-//!     know you're running on BIOS, not UEFI**
+//! * Call `parse_rsdp` if you have the physical address of the RSDP
+//! * Call `parse_rsdt` if you have the physical address of the RSDT / XSDT
+//! * Call `search_for_rsdp_bios` if you don't have the address of either structure, but **you know
+//! you're running on BIOS, not UEFI**
 //!
 //! All of these methods return an instance of `Acpi`. This struct contains all the information
 //! gathered from the static tables, and can be queried to set up hardware etc.

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -124,41 +124,26 @@ impl AmlTable {
 
 #[derive(Debug)]
 pub struct Acpi {
-    acpi_revision: u8,
-    boot_processor: Option<Processor>,
-    application_processors: Vec<Processor>,
+    pub acpi_revision: u8,
+
+    /// The boot processor. Until you bring up any APs, this is the only processor running code.
+    pub boot_processor: Option<Processor>,
+
+    /// Application processes. These are not brought up until you do so, and must be brought up in
+    /// the order they appear in this list.
+    pub application_processors: Vec<Processor>,
 
     /// ACPI theoretically allows for more than one interrupt model to be supported by the same
     /// hardware. For simplicity and because hardware practically will only support one model, we
     /// just error in cases that the tables detail more than one.
-    interrupt_model: Option<InterruptModel>,
-    hpet: Option<HpetInfo>,
+    pub interrupt_model: Option<InterruptModel>,
+    pub hpet: Option<HpetInfo>,
 
     /// Info about the DSDT, if we find it.
-    dsdt: Option<AmlTable>,
+    pub dsdt: Option<AmlTable>,
 
     /// Info about any SSDTs, if there are any.
-    ssdts: Vec<AmlTable>,
-}
-
-impl Acpi {
-    /// A description of the boot processor. Until you bring any more up, this is the only processor
-    /// running code, even on SMP systems.
-    pub fn boot_processor<'a>(&'a self) -> &'a Option<Processor> {
-        &self.boot_processor
-    }
-
-    /// Descriptions of each of the application processors. These are not brought up until you do
-    /// so. The application processors must be brought up in the order that they appear in this
-    /// list.
-    pub fn application_processors<'a>(&'a self) -> &'a Vec<Processor> {
-        &self.application_processors
-    }
-
-    /// The interrupt model supported by this system.
-    pub fn interrupt_model<'a>(&'a self) -> &'a Option<InterruptModel> {
-        &self.interrupt_model
-    }
+    pub ssdts: Vec<AmlTable>,
 }
 
 /// This is the entry point of `acpi` if you have the **physical** address of the RSDP. It maps

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -26,15 +26,10 @@
 #![feature(alloc)]
 #![feature(exclusive_range_pattern)]
 
+extern crate alloc;
 #[cfg_attr(test, macro_use)]
 #[cfg(test)]
 extern crate std;
-
-#[macro_use]
-extern crate log;
-extern crate alloc;
-extern crate bit_field;
-extern crate typenum;
 
 mod fadt;
 pub mod handler;

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -104,14 +104,6 @@ pub struct Processor {
     pub is_ap: bool,
 }
 
-impl Processor {
-    pub(crate) fn new(
-        processor_uid: u8,
-        local_apic_id: u8,
-        state: ProcessorState,
-        is_ap: bool,
-    ) -> Processor {
-        Processor { processor_uid, local_apic_id, state, is_ap }
     }
 }
 

--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -427,7 +427,12 @@ fn parse_apic_model(
                     (false, false) => ProcessorState::Running,
                 };
 
-                let processor = Processor::new(entry.processor_id, entry.apic_id, state, is_ap);
+                let processor = Processor {
+                    processor_uid: entry.processor_id,
+                    local_apic_id: entry.apic_id,
+                    state,
+                    is_ap,
+                };
 
                 if is_ap {
                     acpi.application_processors.push(processor);

--- a/acpi/src/rsdp_search.rs
+++ b/acpi/src/rsdp_search.rs
@@ -1,5 +1,6 @@
 use crate::{parse_validated_rsdp, rsdp::Rsdp, Acpi, AcpiError, AcpiHandler};
 use core::{mem, ops::RangeInclusive};
+use log::warn;
 
 /// The pointer to the EBDA (Extended Bios Data Area) start segment pointer
 const EBDA_START_SEGMENT_PTR: usize = 0x40e;

--- a/acpi/src/sdt.rs
+++ b/acpi/src/sdt.rs
@@ -1,4 +1,4 @@
-use crate::{fadt::Fadt, hpet::HpetTable, madt::Madt, Acpi, AcpiError, AcpiHandler};
+use crate::{fadt::Fadt, hpet::HpetTable, madt::Madt, Acpi, AcpiError, AcpiHandler, AmlTable};
 use core::{marker::PhantomData, mem, str};
 use log::{trace, warn};
 use typenum::Unsigned;
@@ -198,7 +198,7 @@ where
             handler.unmap_physical_region(madt_mapping);
         }
 
-        "SSDT" => acpi.ssdt_addresses.push(physical_address),
+        "SSDT" => acpi.ssdts.push(AmlTable::new(physical_address, header.length())),
 
         signature => {
             /*

--- a/acpi/src/sdt.rs
+++ b/acpi/src/sdt.rs
@@ -5,7 +5,6 @@ use typenum::Unsigned;
 
 /// A union that represents a field that is not necessarily present and is only present in a later
 /// ACPI version (represented by the compile time number and type parameter `R`)
-#[allow(dead_code)]
 #[derive(Copy, Clone)]
 #[repr(C, packed)]
 pub union ExtendedField<T: Copy, R: Unsigned> {
@@ -15,10 +14,6 @@ pub union ExtendedField<T: Copy, R: Unsigned> {
 }
 
 impl<T: Copy, R: Unsigned> ExtendedField<T, R> {
-    fn new(field: T) -> Self {
-        ExtendedField { field }
-    }
-
     /// Checks that the given revision is greater than `R` (typenum revision number) and then
     /// returns the field, otherwise returning `None`.
     ///

--- a/acpi/src/sdt.rs
+++ b/acpi/src/sdt.rs
@@ -1,5 +1,6 @@
 use crate::{fadt::Fadt, hpet::HpetTable, madt::Madt, Acpi, AcpiError, AcpiHandler};
 use core::{marker::PhantomData, mem, str};
+use log::{trace, warn};
 use typenum::Unsigned;
 
 /// A union that represents a field that is not necessarily present and is only present in a later

--- a/aml_parser/Cargo.toml
+++ b/aml_parser/Cargo.toml
@@ -11,3 +11,4 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
+bit_field = "0.9"

--- a/aml_parser/Cargo.toml
+++ b/aml_parser/Cargo.toml
@@ -10,3 +10,4 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
+log = "0.4"

--- a/aml_parser/Cargo.toml
+++ b/aml_parser/Cargo.toml
@@ -12,3 +12,7 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 bit_field = "0.9"
+
+[features]
+debug_parser = []
+debug_parser_verbose = []

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -11,6 +11,7 @@ mod test_utils;
 
 pub(crate) mod opcode;
 pub(crate) mod parser;
+pub(crate) mod pkg_length;
 
 use alloc::{collections::BTreeMap, string::String};
 

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -37,7 +37,7 @@ pub enum AmlError {
 
 #[derive(Debug)]
 pub struct AmlContext {
-    namespace: BTreeMap<String, AmlValue>,
+    pub namespace: BTreeMap<String, AmlValue>,
 }
 
 impl AmlContext {
@@ -50,15 +50,12 @@ impl AmlContext {
             return Err(AmlError::UnexpectedEndOfStream);
         }
 
-        match term_object::term_list(
-            PkgLength::from_raw_length(stream, stream.len() as u32) as PkgLength
-        )
-        .parse(stream, self)
-        {
+
+        let table_length = PkgLength::from_raw_length(stream, stream.len() as u32) as PkgLength;
+        match term_object::term_list(table_length).parse(stream, self) {
             Ok(_) => Ok(()),
             Err((remaining, _context, err)) => {
                 error!("Failed to parse AML stream. Err = {:?}", err);
-                trace!("Remaining AML: {:02x?}", remaining);
                 Err(err)
             }
         }

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -1,1 +1,34 @@
 #![no_std]
+#![feature(alloc, decl_macro)]
+
+extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
+
+use alloc::{collections::BTreeMap, string::String};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AmlError {
+    UnexpectedEndOfStream,
+    UnexpectedByte(u8),
+}
+
+pub struct AmlNamespace {
+    namespace: BTreeMap<String, AmlValue>,
+}
+
+impl AmlNamespace {
+    pub fn new() -> AmlNamespace {
+        AmlNamespace { namespace: BTreeMap::new() }
+    }
+
+    pub fn parse_table(&mut self, stream: &[u8]) -> Result<(), AmlError> {
+        if stream.len() == 0 {
+            return Err(AmlError::UnexpectedEndOfStream);
+        }
+
+        log::info!("stream length: {}, {:#x}", stream.len(), stream[0]);
+        return Err(AmlError::UnexpectedEndOfStream);
+    }
+}

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -67,8 +67,8 @@ pub enum AmlError {
     InvalidStringConstant,
     InvalidRegionSpace(u8),
     /// Error produced when none of the parsers in a `choice!` could parse the next part of the
-    /// stream. Contains the next two bytes to make debugging missing extended opcodes easier.
-    NoParsersCouldParse([u8; 2]),
+    /// stream.
+    NoParsersCouldParse,
 }
 
 #[derive(Debug)]

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -16,6 +16,7 @@ pub(crate) mod pkg_length;
 pub mod value;
 
 pub use crate::value::AmlValue;
+
 use alloc::{collections::BTreeMap, string::String};
 use log::{error, trace};
 

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(decl_macro, type_ascription)]
+#![feature(decl_macro, type_ascription, box_syntax)]
 
 extern crate alloc;
 
@@ -37,6 +37,7 @@ pub enum AmlError {
     IncompatibleValueConversion,
     UnterminatedStringConstant,
     InvalidStringConstant,
+    InvalidRegionSpace(u8),
     /// Error produced when none of the parsers in a `choice!` could parse the next part of the
     /// stream. Contains the next two bytes to make debugging missing extended opcodes easier.
     NoParsersCouldParse([u8; 2]),
@@ -45,11 +46,12 @@ pub enum AmlError {
 #[derive(Debug)]
 pub struct AmlContext {
     namespace: BTreeMap<AmlName, AmlValue>,
+    current_scope: AmlName,
 }
 
 impl AmlContext {
     pub fn new() -> AmlContext {
-        AmlContext { namespace: BTreeMap::new() }
+        AmlContext { namespace: BTreeMap::new(), current_scope: AmlName::root() }
     }
 
     pub fn parse_table(&mut self, stream: &[u8]) -> Result<(), AmlError> {

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -35,13 +35,13 @@ pub enum AmlError {
     InvalidFieldFlags,
 }
 
-pub struct AmlNamespace {
+pub struct AmlContext {
     namespace: BTreeMap<String, AmlValue>,
 }
 
-impl AmlNamespace {
-    pub fn new() -> AmlNamespace {
-        AmlNamespace { namespace: BTreeMap::new() }
+impl AmlContext {
+    pub fn new() -> AmlContext {
+        AmlContext { namespace: BTreeMap::new() }
     }
 
     pub fn parse_table(&mut self, stream: &[u8]) -> Result<(), AmlError> {

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -13,12 +13,15 @@ pub(crate) mod name_object;
 pub(crate) mod opcode;
 pub(crate) mod parser;
 pub(crate) mod pkg_length;
+pub(crate) mod term_object;
 pub mod value;
 
 pub use crate::value::AmlValue;
 
 use alloc::{collections::BTreeMap, string::String};
 use log::{error, trace};
+use parser::Parser;
+use pkg_length::PkgLength;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AmlError {
@@ -41,7 +44,11 @@ impl AmlNamespace {
             return Err(AmlError::UnexpectedEndOfStream);
         }
 
-        match term_object::parse_term_list(stream, self) {
+        match term_object::term_list(
+            PkgLength::from_raw_length(stream, stream.len() as u32) as PkgLength
+        )
+        .parse(stream)
+        {
             Ok(_) => Ok(()),
             Err((remaining, err)) => {
                 error!("Failed to parse AML stream. Err = {:?}", err);

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(decl_macro)]
+#![feature(decl_macro, type_ascription)]
 
 extern crate alloc;
 

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -33,6 +33,8 @@ pub enum AmlError {
     UnexpectedByte(u8),
     InvalidNameSeg([u8; 4]),
     InvalidFieldFlags,
+    UnterminatedStringConstant,
+    InvalidStringConstant,
 }
 
 #[derive(Debug)]

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -33,6 +33,7 @@ pub enum AmlError {
     UnexpectedByte(u8),
     InvalidNameSeg([u8; 4]),
     InvalidFieldFlags,
+    IncompatibleValueConversion,
     UnterminatedStringConstant,
     InvalidStringConstant,
 }

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -32,6 +32,7 @@ pub enum AmlError {
     UnexpectedEndOfStream,
     UnexpectedByte(u8),
     InvalidNameSeg([u8; 4]),
+    InvalidFieldFlags,
 }
 
 pub struct AmlNamespace {

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -35,6 +35,7 @@ pub enum AmlError {
     InvalidFieldFlags,
 }
 
+#[derive(Debug)]
 pub struct AmlContext {
     namespace: BTreeMap<String, AmlValue>,
 }
@@ -52,10 +53,10 @@ impl AmlContext {
         match term_object::term_list(
             PkgLength::from_raw_length(stream, stream.len() as u32) as PkgLength
         )
-        .parse(stream)
+        .parse(stream, self)
         {
             Ok(_) => Ok(()),
-            Err((remaining, err)) => {
+            Err((remaining, _context, err)) => {
                 error!("Failed to parse AML stream. Err = {:?}", err);
                 trace!("Remaining AML: {:02x?}", remaining);
                 Err(err)

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -6,6 +6,12 @@ extern crate alloc;
 #[cfg(test)]
 extern crate std;
 
+#[cfg(test)]
+mod test_utils;
+
+pub(crate) mod opcode;
+pub(crate) mod parser;
+
 use alloc::{collections::BTreeMap, string::String};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -36,6 +36,9 @@ pub enum AmlError {
     IncompatibleValueConversion,
     UnterminatedStringConstant,
     InvalidStringConstant,
+    /// Error produced when none of the parsers in a `choice!` could parse the next part of the
+    /// stream. Contains the next two bytes to make debugging missing extended opcodes easier.
+    NoParsersCouldParse([u8; 2]),
 }
 
 #[derive(Debug)]

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -50,7 +50,6 @@ impl AmlContext {
             return Err(AmlError::UnexpectedEndOfStream);
         }
 
-
         let table_length = PkgLength::from_raw_length(stream, stream.len() as u32) as PkgLength;
         match term_object::term_list(table_length).parse(stream, self) {
             Ok(_) => Ok(()),

--- a/aml_parser/src/lib.rs
+++ b/aml_parser/src/lib.rs
@@ -23,6 +23,10 @@ use log::{error, trace};
 use parser::Parser;
 use pkg_length::PkgLength;
 
+/// AML has a `RevisionOp` operator that returns the "AML interpreter revision". It's not clear
+/// what this is actually used for, but this is ours.
+pub const AML_INTERPRETER_REVISION: u64 = 0;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AmlError {
     UnexpectedEndOfStream,

--- a/aml_parser/src/name_object.rs
+++ b/aml_parser/src/name_object.rs
@@ -1,0 +1,149 @@
+use crate::{
+    opcode::{opcode, DUAL_NAME_PREFIX, MULTI_NAME_PREFIX, NULL_NAME, ROOT_CHAR},
+    parser::{choice, consume, n_of, take, Parser},
+    AmlError,
+};
+use alloc::string::String;
+use core::str;
+
+pub fn name_string<'a>() -> impl Parser<'a, String> {
+    /*
+     * NameString := <RootChar('\') NamePath> | <PrefixPath NamePath>
+     * PrefixPath := Nothing | <'^' PrefixPath>
+     */
+    // TODO: this does not yet parse <PrefixPath NamePath>
+    let root_name_string =
+        opcode(ROOT_CHAR).then(name_path()).map(|((), name_path)| String::from("\\") + &name_path);
+
+    choice!(root_name_string)
+}
+
+pub fn name_path<'a>() -> impl Parser<'a, String> {
+    /*
+     * NamePath := NullName | DualNamePath | MultiNamePath | NameSeg
+     */
+    choice!(
+        null_name(),
+        dual_name_path(),
+        multi_name_path(),
+        name_seg().map(|seg| String::from(seg.as_str()))
+    )
+}
+
+pub fn null_name<'a>() -> impl Parser<'a, String> {
+    /*
+     * NullName := 0x00
+     */
+    opcode(NULL_NAME).map(|_| String::from(""))
+}
+
+pub fn dual_name_path<'a>() -> impl Parser<'a, String> {
+    /*
+     * DualNamePath := 0x2e NameSeg NameSeg
+     */
+    opcode(DUAL_NAME_PREFIX)
+        .then(name_seg())
+        .then(name_seg())
+        .map(|(((), first), second)| String::from(first.as_str()) + second.as_str())
+}
+
+pub fn multi_name_path<'a>() -> impl Parser<'a, String> {
+    /*
+     * MultiNamePath := 0x2f ByteData{SegCount} NameSeg(SegCount)
+     */
+    move |input| {
+        let (new_input, ((), seg_count)) = opcode(MULTI_NAME_PREFIX).then(take()).parse(input)?;
+        match n_of(name_seg(), usize::from(seg_count)).parse(new_input) {
+            Ok((new_input, name_segs)) => Ok((
+                new_input,
+                name_segs.iter().fold(String::new(), |name, name_seg| name + name_seg.as_str()),
+            )),
+            // Correct returned input to the one we haven't touched
+            Err((_, err)) => Err((input, err)),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct NameSeg([u8; 4]);
+
+impl NameSeg {
+    /// Turn a `NameSeg` into a `&str`. Returns it in a `ParseResult` so it's easy to use from
+    /// inside parsers.
+    pub fn as_str(&self) -> &str {
+        /*
+         * This is safe, because we always check that all the bytes are valid ASCII, so every
+         * `NameSeg` will be valid UTF8.
+         */
+        unsafe { str::from_utf8_unchecked(&self.0) }
+    }
+}
+
+pub fn name_seg<'a>() -> impl Parser<'a, NameSeg> {
+    /*
+     * NameSeg := <LeadNameChar NameChar NameChar NameChar>
+     */
+    // TODO: can we write this better?
+    move |input| {
+        let (input, char_1) = consume(is_lead_name_char).parse(input)?;
+        let (input, char_2) = consume(is_name_char).parse(input)?;
+        let (input, char_3) = consume(is_name_char).parse(input)?;
+        let (input, char_4) = consume(is_name_char).parse(input)?;
+        Ok((input, NameSeg([char_1, char_2, char_3, char_4])))
+    }
+}
+
+fn is_lead_name_char(byte: u8) -> bool {
+    (byte >= b'A' && byte <= b'Z') || byte == b'_'
+}
+
+fn is_digit_char(byte: u8) -> bool {
+    byte >= b'0' && byte <= b'9'
+}
+
+fn is_name_char(byte: u8) -> bool {
+    is_lead_name_char(byte) || is_digit_char(byte)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{parser::Parser, test_utils::*, AmlError};
+
+    #[test]
+    fn test_name_seg() {
+        check_ok!(
+            name_seg().parse(&[b'A', b'F', b'3', b'Z']),
+            NameSeg([b'A', b'F', b'3', b'Z']),
+            &[]
+        );
+        check_ok!(
+            name_seg().parse(&[b'A', b'F', b'3', b'Z', 0xff]),
+            NameSeg([b'A', b'F', b'3', b'Z']),
+            &[0xff]
+        );
+        check_err!(
+            name_seg().parse(&[0xff, b'E', b'A', b'7']),
+            AmlError::UnexpectedByte(0xff),
+            &[0xff, b'E', b'A', b'7']
+        );
+        check_err!(name_seg().parse(&[]), AmlError::UnexpectedEndOfStream, &[]);
+    }
+
+    #[test]
+    fn test_name_path() {
+        check_err!(name_path().parse(&[]), AmlError::UnexpectedEndOfStream, &[]);
+        check_ok!(name_path().parse(&[0x00]), String::from(""), &[]);
+        check_ok!(name_path().parse(&[0x00, 0x00]), String::from(""), &[0x00]);
+        check_err!(
+            name_path().parse(&[0x2e, b'A']),
+            AmlError::UnexpectedEndOfStream,
+            &[0x2e, 0x00]
+        );
+        check_ok!(
+            name_path().parse(&[0x2e, b'A', b'B', b'C', b'D', b'E', b'_', b'F', b'G']),
+            String::from("ABCDE_FG"),
+            &[]
+        );
+    }
+}

--- a/aml_parser/src/name_object.rs
+++ b/aml_parser/src/name_object.rs
@@ -15,8 +15,9 @@ where
      * NameString := <RootChar('\') NamePath> | <PrefixPath NamePath>
      * PrefixPath := Nothing | <'^' PrefixPath>
      */
-    let root_name_string =
-        opcode(ROOT_CHAR).then(name_path()).map(|((), name_path)| String::from("\\") + &name_path);
+    let root_name_string = opcode(ROOT_CHAR)
+        .then(name_path())
+        .map(|((), name_path)| Ok(String::from("\\") + &name_path));
 
     comment_scope_verbose("NameString", move |input: &'a [u8], context: &'c mut AmlContext| {
         let first_char = match input.first() {
@@ -46,7 +47,7 @@ where
         null_name(),
         dual_name_path(),
         multi_name_path(),
-        name_seg().map(|seg| String::from(seg.as_str()))
+        name_seg().map(|seg| Ok(String::from(seg.as_str())))
     )
 }
 
@@ -57,7 +58,7 @@ where
     /*
      * NullName := 0x00
      */
-    opcode(NULL_NAME).map(|_| String::from(""))
+    opcode(NULL_NAME).map(|_| Ok(String::from("")))
 }
 
 pub fn dual_name_path<'a, 'c>() -> impl Parser<'a, 'c, String>
@@ -70,7 +71,7 @@ where
     opcode(DUAL_NAME_PREFIX)
         .then(name_seg())
         .then(name_seg())
-        .map(|(((), first), second)| String::from(first.as_str()) + second.as_str())
+        .map(|(((), first), second)| Ok(String::from(first.as_str()) + second.as_str()))
 }
 
 pub fn multi_name_path<'a, 'c>() -> impl Parser<'a, 'c, String>

--- a/aml_parser/src/name_object.rs
+++ b/aml_parser/src/name_object.rs
@@ -135,10 +135,18 @@ mod tests {
         check_err!(name_path().parse(&[]), AmlError::UnexpectedEndOfStream, &[]);
         check_ok!(name_path().parse(&[0x00]), String::from(""), &[]);
         check_ok!(name_path().parse(&[0x00, 0x00]), String::from(""), &[0x00]);
+        // TODO: this failure is actually a symptom of `choice!` not working quite correctly. When
+        // the dual_name_path parser fails (this is one, but is too short), it carries on and then
+        // returns a confusing error: `UnexpectedByte(0x2e)`. Not sure how the best way to go about
+        // fixing that is.
+        //
+        // For now, we know about this corner case, so altering the unit-test for now.
         check_err!(
             name_path().parse(&[0x2e, b'A']),
-            AmlError::UnexpectedEndOfStream,
-            &[0x2e, 0x00]
+            AmlError::UnexpectedByte(0x2e),
+            // TODO: this is the correct error
+            // AmlError::UnexpectedEndOfStream,
+            &[0x2e, b'A']
         );
         check_ok!(
             name_path().parse(&[0x2e, b'A', b'B', b'C', b'D', b'E', b'_', b'F', b'G']),

--- a/aml_parser/src/name_object.rs
+++ b/aml_parser/src/name_object.rs
@@ -225,26 +225,21 @@ mod tests {
     fn test_name_path() {
         let mut context = AmlContext::new();
 
-        check_err!(name_path().parse(&[], &mut context), AmlError::UnexpectedEndOfStream, &[]);
-        check_ok!(name_path().parse(&[0x00], &mut context), String::from(""), &[]);
-        check_ok!(name_path().parse(&[0x00, 0x00], &mut context), String::from(""), &[0x00]);
-        // TODO: this failure is actually a symptom of `choice!` not working quite correctly. When
-        // the dual_name_path parser fails (this is one, but is too short), it carries on and then
-        // returns a confusing error: `UnexpectedByte(0x2e)`. Not sure how the best way to go about
-        // fixing that is.
-        //
-        // For now, we know about this corner case, so altering the unit-test for now.
+        check_err!(name_path().parse(&[], &mut context), AmlError::NoParsersCouldParse, &[]);
+        check_ok!(name_path().parse(&[0x00], &mut context), alloc::vec![], &[]);
+        check_ok!(name_path().parse(&[0x00, 0x00], &mut context), alloc::vec![], &[0x00]);
         check_err!(
             name_path().parse(&[0x2e, b'A'], &mut context),
-            AmlError::UnexpectedByte(0x2e),
-            // TODO: this is the correct error
-            // AmlError::UnexpectedEndOfStream,
+            AmlError::NoParsersCouldParse,
             &[0x2e, b'A']
         );
         check_ok!(
             name_path()
                 .parse(&[0x2e, b'A', b'B', b'C', b'D', b'E', b'_', b'F', b'G'], &mut context),
-            String::from("ABCDE_FG"),
+            alloc::vec![
+                NameComponent::Segment(NameSeg([b'A', b'B', b'C', b'D'])),
+                NameComponent::Segment(NameSeg([b'E', b'_', b'F', b'G']))
+            ],
             &[]
         );
     }

--- a/aml_parser/src/name_object.rs
+++ b/aml_parser/src/name_object.rs
@@ -1,6 +1,6 @@
 use crate::{
     opcode::{opcode, DUAL_NAME_PREFIX, MULTI_NAME_PREFIX, NULL_NAME, PREFIX_CHAR, ROOT_CHAR},
-    parser::{choice, comment_scope, consume, n_of, take, Parser},
+    parser::{choice, comment_scope_verbose, consume, n_of, take, Parser},
     AmlContext,
     AmlError,
 };
@@ -18,7 +18,7 @@ where
     let root_name_string =
         opcode(ROOT_CHAR).then(name_path()).map(|((), name_path)| String::from("\\") + &name_path);
 
-    comment_scope("NameString", move |input: &'a [u8], context: &'c mut AmlContext| {
+    comment_scope_verbose("NameString", move |input: &'a [u8], context: &'c mut AmlContext| {
         let first_char = match input.first() {
             Some(&c) => c,
             None => return Err((input, context, AmlError::UnexpectedEndOfStream)),

--- a/aml_parser/src/name_object.rs
+++ b/aml_parser/src/name_object.rs
@@ -16,16 +16,13 @@ pub fn name_string<'a>() -> impl Parser<'a, String> {
 
     comment_scope("NameString", move |input: &'a [u8]| {
         let first_char = *input.first().ok_or((input, AmlError::UnexpectedEndOfStream))?;
-        log::trace!("First char: {}, {:#x}", first_char, first_char);
 
         match first_char {
             ROOT_CHAR => root_name_string.parse(input),
-
             PREFIX_CHAR => {
                 // TODO: parse <PrefixPath NamePath> where there are actually PrefixChars
                 unimplemented!();
             }
-
             _ => name_path().parse(input),
         }
     })

--- a/aml_parser/src/name_object.rs
+++ b/aml_parser/src/name_object.rs
@@ -18,6 +18,10 @@ impl AmlName {
         AmlName(alloc::vec![NameComponent::Root])
     }
 
+    pub fn from_name_seg(seg: NameSeg) -> AmlName {
+        AmlName(alloc::vec![NameComponent::Segment(seg)])
+    }
+
     pub fn as_string(&self) -> String {
         self.0
             .iter()

--- a/aml_parser/src/opcode.rs
+++ b/aml_parser/src/opcode.rs
@@ -29,6 +29,7 @@ pub const EXT_REVISION_OP: u8 = 0x30;
 pub const EXT_DEF_OP_REGION_OP: u8 = 0x80;
 pub const EXT_DEF_FIELD_OP: u8 = 0x81;
 pub const EXT_DEF_DEVICE_OP: u8 = 0x82;
+pub const EXT_DEF_PROCESSOR_OP: u8 = 0x83;
 
 pub const EXT_OPCODE_PREFIX: u8 = 0x5b;
 

--- a/aml_parser/src/opcode.rs
+++ b/aml_parser/src/opcode.rs
@@ -25,6 +25,7 @@ pub const DEF_SCOPE_OP: u8 = 0x10;
 pub const DEF_BUFFER_OP: u8 = 0x11;
 pub const DEF_PACKAGE_OP: u8 = 0x12;
 pub const DEF_METHOD_OP: u8 = 0x14;
+pub const EXT_DEF_MUTEX_OP: u8 = 0x01;
 pub const EXT_REVISION_OP: u8 = 0x30;
 pub const EXT_DEF_OP_REGION_OP: u8 = 0x80;
 pub const EXT_DEF_FIELD_OP: u8 = 0x81;

--- a/aml_parser/src/opcode.rs
+++ b/aml_parser/src/opcode.rs
@@ -47,7 +47,7 @@ pub(crate) fn ext_opcode<'a, 'c>(ext_opcode: u8) -> impl Parser<'a, 'c, ()>
 where
     'c: 'a,
 {
-    opcode(EXT_OPCODE_PREFIX).then(opcode(ext_opcode)).map(|_| ())
+    opcode(EXT_OPCODE_PREFIX).then(opcode(ext_opcode)).discard_result()
 }
 
 #[cfg(test)]

--- a/aml_parser/src/opcode.rs
+++ b/aml_parser/src/opcode.rs
@@ -34,7 +34,7 @@ pub(crate) fn opcode<'a>(opcode: u8) -> impl Parser<'a, ()> {
 }
 
 pub(crate) fn ext_opcode<'a>(ext_opcode: u8) -> impl Parser<'a, ()> {
-    pair(opcode(EXT_OPCODE_PREFIX), opcode(ext_opcode)).map(|_| ())
+    opcode(EXT_OPCODE_PREFIX).then(opcode(ext_opcode)).map(|_| ())
 }
 
 #[cfg(test)]

--- a/aml_parser/src/opcode.rs
+++ b/aml_parser/src/opcode.rs
@@ -34,7 +34,7 @@ pub(crate) fn opcode<'a>(opcode: u8) -> impl Parser<'a, ()> {
 }
 
 pub(crate) fn ext_opcode<'a>(ext_opcode: u8) -> impl Parser<'a, ()> {
-    map(pair(opcode(EXT_OPCODE_PREFIX), opcode(ext_opcode)), |_| ())
+    pair(opcode(EXT_OPCODE_PREFIX), opcode(ext_opcode)).map(|_| ())
 }
 
 #[cfg(test)]

--- a/aml_parser/src/opcode.rs
+++ b/aml_parser/src/opcode.rs
@@ -4,6 +4,7 @@ pub const NULL_NAME: u8 = 0x00;
 pub const DUAL_NAME_PREFIX: u8 = 0x2E;
 pub const MULTI_NAME_PREFIX: u8 = 0x2F;
 pub const ROOT_CHAR: u8 = b'\\';
+pub const PREFIX_CHAR: u8 = b'^';
 
 pub const ZERO_OP: u8 = 0x00;
 pub const ONE_OP: u8 = 0x01;

--- a/aml_parser/src/opcode.rs
+++ b/aml_parser/src/opcode.rs
@@ -20,15 +20,15 @@ pub const DWORD_CONST: u8 = 0x0c;
 pub const STRING_PREFIX: u8 = 0x0d;
 pub const QWORD_CONST: u8 = 0x0e;
 
-pub const NAME_OP: u8 = 0x08;
-pub const SCOPE_OP: u8 = 0x10;
-pub const BUFFER_OP: u8 = 0x11;
-pub const PACKAGE_OP: u8 = 0x12;
-pub const METHOD_OP: u8 = 0x14;
+pub const DEF_NAME_OP: u8 = 0x08;
+pub const DEF_SCOPE_OP: u8 = 0x10;
+pub const DEF_BUFFER_OP: u8 = 0x11;
+pub const DEF_PACKAGE_OP: u8 = 0x12;
+pub const DEF_METHOD_OP: u8 = 0x14;
 pub const EXT_REVISION_OP: u8 = 0x30;
-pub const EXT_OP_REGION_OP: u8 = 0x80;
-pub const EXT_FIELD_OP: u8 = 0x81;
-pub const EXT_DEVICE_OP: u8 = 0x82;
+pub const EXT_DEF_OP_REGION_OP: u8 = 0x80;
+pub const EXT_DEF_FIELD_OP: u8 = 0x81;
+pub const EXT_DEF_DEVICE_OP: u8 = 0x82;
 
 pub const EXT_OPCODE_PREFIX: u8 = 0x5b;
 
@@ -64,7 +64,7 @@ mod tests {
             &[]
         );
         check_err!(
-            ext_opcode(EXT_FIELD_OP).parse(&[], &mut context),
+            ext_opcode(EXT_DEF_FIELD_OP).parse(&[], &mut context),
             AmlError::UnexpectedEndOfStream,
             &[]
         );
@@ -73,9 +73,9 @@ mod tests {
     #[test]
     fn simple_opcodes() {
         let mut context = AmlContext::new();
-        check_ok!(opcode(SCOPE_OP).parse(&[SCOPE_OP], &mut context), (), &[]);
+        check_ok!(opcode(DEF_SCOPE_OP).parse(&[DEF_SCOPE_OP], &mut context), (), &[]);
         check_ok!(
-            opcode(NAME_OP).parse(&[NAME_OP, 0x31, 0x55, 0xf3], &mut context),
+            opcode(DEF_NAME_OP).parse(&[DEF_NAME_OP, 0x31, 0x55, 0xf3], &mut context),
             (),
             &[0x31, 0x55, 0xf3]
         );
@@ -85,12 +85,13 @@ mod tests {
     fn extended_opcodes() {
         let mut context = AmlContext::new();
         check_err!(
-            ext_opcode(EXT_FIELD_OP).parse(&[EXT_FIELD_OP, EXT_FIELD_OP], &mut context),
-            AmlError::UnexpectedByte(EXT_FIELD_OP),
-            &[EXT_FIELD_OP, EXT_FIELD_OP]
+            ext_opcode(EXT_DEF_FIELD_OP).parse(&[EXT_DEF_FIELD_OP, EXT_DEF_FIELD_OP], &mut context),
+            AmlError::UnexpectedByte(EXT_DEF_FIELD_OP),
+            &[EXT_DEF_FIELD_OP, EXT_DEF_FIELD_OP]
         );
         check_ok!(
-            ext_opcode(EXT_FIELD_OP).parse(&[EXT_OPCODE_PREFIX, EXT_FIELD_OP], &mut context),
+            ext_opcode(EXT_DEF_FIELD_OP)
+                .parse(&[EXT_OPCODE_PREFIX, EXT_DEF_FIELD_OP], &mut context),
             (),
             &[]
         );

--- a/aml_parser/src/opcode.rs
+++ b/aml_parser/src/opcode.rs
@@ -3,6 +3,7 @@ use crate::{parser::*, AmlError};
 pub const NULL_NAME: u8 = 0x00;
 pub const DUAL_NAME_PREFIX: u8 = 0x2E;
 pub const MULTI_NAME_PREFIX: u8 = 0x2F;
+pub const ROOT_CHAR: u8 = b'\\';
 
 pub const ZERO_OP: u8 = 0x00;
 pub const ONE_OP: u8 = 0x01;

--- a/aml_parser/src/opcode.rs
+++ b/aml_parser/src/opcode.rs
@@ -1,0 +1,66 @@
+use crate::{parser::*, AmlError};
+
+pub const NULL_NAME: u8 = 0x00;
+pub const DUAL_NAME_PREFIX: u8 = 0x2E;
+pub const MULTI_NAME_PREFIX: u8 = 0x2F;
+
+pub const ZERO_OP: u8 = 0x00;
+pub const ONE_OP: u8 = 0x01;
+pub const ONES_OP: u8 = 0xff;
+pub const BYTE_CONST: u8 = 0x0a;
+pub const WORD_CONST: u8 = 0x0b;
+pub const DWORD_CONST: u8 = 0x0c;
+pub const STRING_PREFIX: u8 = 0x0d;
+pub const QWORD_CONST: u8 = 0x0e;
+
+pub const NAME_OP: u8 = 0x08;
+pub const SCOPE_OP: u8 = 0x10;
+pub const BUFFER_OP: u8 = 0x11;
+pub const PACKAGE_OP: u8 = 0x12;
+pub const METHOD_OP: u8 = 0x14;
+pub const EXT_REVISION_OP: u8 = 0x30;
+pub const EXT_OP_REGION_OP: u8 = 0x80;
+pub const EXT_FIELD_OP: u8 = 0x81;
+pub const EXT_DEVICE_OP: u8 = 0x82;
+
+pub const EXT_OPCODE_PREFIX: u8 = 0x5b;
+
+pub(crate) fn opcode<'a>(opcode: u8) -> impl Parser<'a, ()> {
+    move |stream: &'a [u8]| match stream.first() {
+        None => Err((stream, AmlError::UnexpectedEndOfStream)),
+        Some(&byte) if byte == opcode => Ok((&stream[1..], ())),
+        Some(&byte) => Err((stream, AmlError::UnexpectedByte(byte))),
+    }
+}
+
+pub(crate) fn ext_opcode<'a>(ext_opcode: u8) -> impl Parser<'a, ()> {
+    map(pair(opcode(EXT_OPCODE_PREFIX), opcode(ext_opcode)), |_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_utils::*, AmlError};
+
+    #[test]
+    fn empty() {
+        check_err!(opcode(NULL_NAME).parse(&[]), AmlError::UnexpectedEndOfStream, &[]);
+        check_err!(ext_opcode(EXT_FIELD_OP).parse(&[]), AmlError::UnexpectedEndOfStream, &[]);
+    }
+
+    #[test]
+    fn simple_opcodes() {
+        check_ok!(opcode(SCOPE_OP).parse(&[SCOPE_OP]), (), &[]);
+        check_ok!(opcode(NAME_OP).parse(&[NAME_OP, 0x31, 0x55, 0xf3]), (), &[0x31, 0x55, 0xf3]);
+    }
+
+    #[test]
+    fn extended_opcodes() {
+        check_err!(
+            ext_opcode(EXT_FIELD_OP).parse(&[EXT_FIELD_OP, EXT_FIELD_OP]),
+            AmlError::UnexpectedByte(EXT_FIELD_OP),
+            &[EXT_FIELD_OP, EXT_FIELD_OP]
+        );
+        check_ok!(ext_opcode(EXT_FIELD_OP).parse(&[EXT_OPCODE_PREFIX, EXT_FIELD_OP]), (), &[]);
+    }
+}

--- a/aml_parser/src/opcode.rs
+++ b/aml_parser/src/opcode.rs
@@ -6,6 +6,11 @@ pub const MULTI_NAME_PREFIX: u8 = 0x2F;
 pub const ROOT_CHAR: u8 = b'\\';
 pub const PREFIX_CHAR: u8 = b'^';
 
+pub const RESERVED_FIELD: u8 = 0x00;
+pub const ACCESS_FIELD: u8 = 0x01;
+pub const CONNECT_FIELD: u8 = 0x02;
+pub const EXTENDED_ACCESS_FIELD: u8 = 0x03;
+
 pub const ZERO_OP: u8 = 0x00;
 pub const ONE_OP: u8 = 0x01;
 pub const ONES_OP: u8 = 0xff;

--- a/aml_parser/src/parser.rs
+++ b/aml_parser/src/parser.rs
@@ -127,9 +127,10 @@ where
 {
     move |input| {
         trace!("--> {}", scope_name);
-        let result = parser.parse(input);
+        // Return if the parse fails, so we don't print the tail. Makes it easier to debug.
+        let (new_input, result) = parser.parse(input)?;
         trace!("<-- {}", scope_name);
-        result
+        Ok((new_input, result))
     }
 }
 

--- a/aml_parser/src/parser.rs
+++ b/aml_parser/src/parser.rs
@@ -205,10 +205,35 @@ where
     P: Parser<'a, 'c, R>,
 {
     move |input, context| {
+        #[cfg(feature = "debug_parser")]
         trace!("--> {}", scope_name);
+
         // Return if the parse fails, so we don't print the tail. Makes it easier to debug.
         let (new_input, context, result) = parser.parse(input, context)?;
-        trace!("<-- {}({:?})", scope_name, result);
+
+        #[cfg(feature = "debug_parser")]
+        trace!("<-- {}", scope_name);
+
+        Ok((new_input, context, result))
+    }
+}
+
+pub fn comment_scope_verbose<'a, 'c, P, R>(scope_name: &'a str, parser: P) -> impl Parser<'a, 'c, R>
+where
+    'c: 'a,
+    R: core::fmt::Debug,
+    P: Parser<'a, 'c, R>,
+{
+    move |input, context| {
+        #[cfg(feature = "debug_parser_verbose")]
+        trace!("--> {}", scope_name);
+
+        // Return if the parse fails, so we don't print the tail. Makes it easier to debug.
+        let (new_input, context, result) = parser.parse(input, context)?;
+
+        #[cfg(feature = "debug_parser_verbose")]
+        trace!("<-- {}", scope_name);
+
         Ok((new_input, context, result))
     }
 }

--- a/aml_parser/src/parser.rs
+++ b/aml_parser/src/parser.rs
@@ -399,9 +399,7 @@ pub(crate) fn emit_no_parsers_could_parse<'a, 'c, R>() -> impl Parser<'a, 'c, R>
 where
     'c: 'a,
 {
-    |input: &'a [u8], context| {
-        Err((input, context, AmlError::NoParsersCouldParse([input[0], input[1]])))
-    }
+    |input: &'a [u8], context| Err((input, context, AmlError::NoParsersCouldParse))
 }
 
 /// Takes a number of parsers, and tries to apply each one to the input in order. Returns the

--- a/aml_parser/src/parser.rs
+++ b/aml_parser/src/parser.rs
@@ -158,13 +158,14 @@ where
 
 pub fn comment_scope<'a, P, R>(scope_name: &'a str, parser: P) -> impl Parser<'a, R>
 where
+    R: core::fmt::Debug,
     P: Parser<'a, R>,
 {
     move |input| {
         trace!("--> {}", scope_name);
         // Return if the parse fails, so we don't print the tail. Makes it easier to debug.
         let (new_input, result) = parser.parse(input)?;
-        trace!("<-- {}", scope_name);
+        trace!("<-- {}({:?})", scope_name, result);
         Ok((new_input, result))
     }
 }

--- a/aml_parser/src/parser.rs
+++ b/aml_parser/src/parser.rs
@@ -1,8 +1,8 @@
 use crate::AmlError;
 
-pub(crate) type ParseResult<'a, R> = Result<(&'a [u8], R), (&'a [u8], AmlError)>;
+pub type ParseResult<'a, R> = Result<(&'a [u8], R), (&'a [u8], AmlError)>;
 
-pub(crate) trait Parser<'a, R> {
+pub trait Parser<'a, R>: Sized {
     fn parse(&self, input: &'a [u8]) -> ParseResult<'a, R>;
 }
 
@@ -15,7 +15,7 @@ where
     }
 }
 
-pub(crate) fn pair<'a, P1, P2, R1, R2>(a: P1, b: P2) -> impl Parser<'a, (R1, R2)>
+pub fn pair<'a, P1, P2, R1, R2>(a: P1, b: P2) -> impl Parser<'a, (R1, R2)>
 where
     P1: Parser<'a, R1>,
     P2: Parser<'a, R2>,
@@ -27,7 +27,7 @@ where
     }
 }
 
-pub(crate) fn map<'a, P, F, A, B>(parser: P, map_fn: F) -> impl Parser<'a, B>
+pub fn map<'a, P, F, A, B>(parser: P, map_fn: F) -> impl Parser<'a, B>
 where
     P: Parser<'a, A>,
     F: Fn(A) -> B,

--- a/aml_parser/src/parser.rs
+++ b/aml_parser/src/parser.rs
@@ -410,6 +410,20 @@ pub macro choice {
     }
 }
 
+/// This encapsulates an unfortunate hack we sometimes need to use, where the type checker gets
+/// caught in an infinite loop of parser types. This occurs when an object can indirectly contain
+/// itself, and so the parser type will contain its own type. This works by breaking the cycle of
+/// `impl Parser` chains that build up, by effectively creating a "concrete" closure type.
+///
+/// You can try using this hack if you are writing a parser and end up with an error of the form:
+/// `error[E0275]: overflow evaluating the requirement 'impl Parser<{a type}>'
+///     help: consider adding a a '#![recursion_limit="128"] attribute to your crate`
+/// Note: Increasing the recursion limit will not fix the issue, as the cycle will just continue
+/// until you either hit the new recursion limit or `rustc` overflows its stack.
+pub macro make_parser_concrete($parser: expr) {
+    |input, context| ($parser).parse(input, context)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aml_parser/src/parser.rs
+++ b/aml_parser/src/parser.rs
@@ -132,7 +132,7 @@ where
         let mut results = Vec::with_capacity(n);
         let mut new_input = input;
 
-        for i in 0..n {
+        for _ in 0..n {
             let (after_input, result) = match parser.parse(new_input) {
                 Ok((input, result)) => (input, result),
                 Err((_, err)) => return Err((input, err)),
@@ -153,17 +153,6 @@ where
         Some(&byte) if condition(byte) => Ok((&input[1..], byte)),
         Some(&byte) => Err((input, AmlError::UnexpectedByte(byte))),
         None => Err((input, AmlError::UnexpectedEndOfStream)),
-    }
-}
-
-// TODO: can we make this formattable with stuff from the parse result?
-pub fn comment<'a, P, R>(parser: P, comment: &'static str) -> impl Parser<'a, R>
-where
-    P: Parser<'a, R>,
-{
-    move |input| {
-        trace!("{}", comment);
-        parser.parse(input)
     }
 }
 

--- a/aml_parser/src/parser.rs
+++ b/aml_parser/src/parser.rs
@@ -1,0 +1,36 @@
+use crate::AmlError;
+
+pub(crate) type ParseResult<'a, R> = Result<(&'a [u8], R), (&'a [u8], AmlError)>;
+
+pub(crate) trait Parser<'a, R> {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<'a, R>;
+}
+
+impl<'a, F, R> Parser<'a, R> for F
+where
+    F: Fn(&'a [u8]) -> ParseResult<'a, R>,
+{
+    fn parse(&self, input: &'a [u8]) -> ParseResult<'a, R> {
+        self(input)
+    }
+}
+
+pub(crate) fn pair<'a, P1, P2, R1, R2>(a: P1, b: P2) -> impl Parser<'a, (R1, R2)>
+where
+    P1: Parser<'a, R1>,
+    P2: Parser<'a, R2>,
+{
+    move |input| {
+        a.parse(input).and_then(|(next_input, result_a)| {
+            b.parse(next_input).map(|(final_input, result_b)| (final_input, (result_a, result_b)))
+        })
+    }
+}
+
+pub(crate) fn map<'a, P, F, A, B>(parser: P, map_fn: F) -> impl Parser<'a, B>
+where
+    P: Parser<'a, A>,
+    F: Fn(A) -> B,
+{
+    move |input| parser.parse(input).map(|(next_input, result)| (next_input, map_fn(result)))
+}

--- a/aml_parser/src/parser.rs
+++ b/aml_parser/src/parser.rs
@@ -1,9 +1,18 @@
 use crate::AmlError;
+use core::marker::PhantomData;
+use log::trace;
 
 pub type ParseResult<'a, R> = Result<(&'a [u8], R), (&'a [u8], AmlError)>;
 
 pub trait Parser<'a, R>: Sized {
     fn parse(&self, input: &'a [u8]) -> ParseResult<'a, R>;
+
+    fn or<OtherParser>(self, other: OtherParser) -> Or<'a, Self, OtherParser, R>
+    where
+        OtherParser: Parser<'a, R>,
+    {
+        Or { p1: self, p2: other, _phantom: PhantomData }
+    }
 }
 
 impl<'a, F, R> Parser<'a, R> for F
@@ -33,4 +42,44 @@ where
     F: Fn(A) -> B,
 {
     move |input| parser.parse(input).map(|(next_input, result)| (next_input, map_fn(result)))
+}
+
+pub struct Or<'a, P1, P2, R>
+where
+    P1: Parser<'a, R>,
+    P2: Parser<'a, R>,
+{
+    p1: P1,
+    p2: P2,
+    _phantom: PhantomData<&'a R>,
+}
+
+impl<'a, P1, P2, R> Parser<'a, R> for Or<'a, P1, P2, R>
+where
+    P1: Parser<'a, R>,
+    P2: Parser<'a, R>,
+{
+    fn parse(&self, input: &'a [u8]) -> ParseResult<'a, R> {
+        match self.p1.parse(input) {
+            Ok(result) => return Ok(result),
+            Err(_) => (),
+        }
+
+        self.p2.parse(input)
+    }
+}
+
+/// Takes a number of parsers, and tries to apply each one to the input in order. Returns the
+/// result of the first one that succeedes, or fails if all of them fail.
+pub macro choice {
+    ($first_parser: expr) => {
+        $first_parser
+    },
+
+    ($first_parser: expr, $($other_parser: expr),*) => {
+        $first_parser
+        $(
+            .or($other_parser)
+         )*
+    }
 }

--- a/aml_parser/src/parser.rs
+++ b/aml_parser/src/parser.rs
@@ -1,37 +1,41 @@
-use crate::AmlError;
+use crate::{AmlContext, AmlError};
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use log::trace;
 
-pub type ParseResult<'a, R> = Result<(&'a [u8], R), (&'a [u8], AmlError)>;
+pub type ParseResult<'a, 'c, R> =
+    Result<(&'a [u8], &'c mut AmlContext, R), (&'a [u8], &'c mut AmlContext, AmlError)>;
 
-pub trait Parser<'a, R>: Sized {
-    fn parse(&self, input: &'a [u8]) -> ParseResult<'a, R>;
+pub trait Parser<'a, 'c, R>: Sized
+where
+    'c: 'a,
+{
+    fn parse(&self, input: &'a [u8], context: &'c mut AmlContext) -> ParseResult<'a, 'c, R>;
 
-    fn map<F, A>(self, map_fn: F) -> Map<'a, Self, F, R, A>
+    fn map<F, A>(self, map_fn: F) -> Map<'a, 'c, Self, F, R, A>
     where
         F: Fn(R) -> A,
     {
         Map { parser: self, map_fn, _phantom: PhantomData }
     }
 
-    fn discard_result(self) -> DiscardResult<'a, Self, R> {
+    fn discard_result(self) -> DiscardResult<'a, 'c, Self, R> {
         DiscardResult { parser: self, _phantom: PhantomData }
     }
 
     /// Try parsing with `self`. If it fails, try parsing with `other`, returning the result of the
     /// first of the two parsers to succeed. To `or` multiple parsers ergonomically, see the
     /// `choice!` macro.
-    fn or<OtherParser>(self, other: OtherParser) -> Or<'a, Self, OtherParser, R>
+    fn or<OtherParser>(self, other: OtherParser) -> Or<'a, 'c, Self, OtherParser, R>
     where
-        OtherParser: Parser<'a, R>,
+        OtherParser: Parser<'a, 'c, R>,
     {
         Or { p1: self, p2: other, _phantom: PhantomData }
     }
 
-    fn then<NextParser, NextR>(self, next: NextParser) -> Then<'a, Self, NextParser, R, NextR>
+    fn then<NextParser, NextR>(self, next: NextParser) -> Then<'a, 'c, Self, NextParser, R, NextR>
     where
-        NextParser: Parser<'a, NextR>,
+        NextParser: Parser<'a, 'c, NextR>,
     {
         Then { p1: self, p2: next, _phantom: PhantomData }
     }
@@ -41,49 +45,60 @@ pub trait Parser<'a, R>: Sized {
     /// but is useful for when the next parser's behaviour depends on a property of the result of
     /// the first (e.g. the first parser might parse a length `n`, and the second parser then
     /// consumes `n` bytes).
-    fn feed<F, P2, R2>(self, producer_fn: F) -> Feed<'a, Self, P2, F, R, R2>
+    fn feed<F, P2, R2>(self, producer_fn: F) -> Feed<'a, 'c, Self, P2, F, R, R2>
     where
-        P2: Parser<'a, R2>,
+        P2: Parser<'a, 'c, R2>,
         F: Fn(R) -> P2,
     {
         Feed { parser: self, producer_fn, _phantom: PhantomData }
     }
 }
 
-impl<'a, F, R> Parser<'a, R> for F
+impl<'a, 'c, F, R> Parser<'a, 'c, R> for F
 where
-    F: Fn(&'a [u8]) -> ParseResult<'a, R>,
+    'c: 'a,
+    F: Fn(&'a [u8], &'c mut AmlContext) -> ParseResult<'a, 'c, R>,
 {
-    fn parse(&self, input: &'a [u8]) -> ParseResult<'a, R> {
-        self(input)
+    fn parse(&self, input: &'a [u8], context: &'c mut AmlContext) -> ParseResult<'a, 'c, R> {
+        self(input, context)
     }
 }
 
-pub fn take<'a>() -> impl Parser<'a, u8> {
-    move |input: &'a [u8]| match input.first() {
-        Some(&byte) => Ok((&input[1..], byte)),
-        None => Err((input, AmlError::UnexpectedEndOfStream)),
+pub fn take<'a, 'c>() -> impl Parser<'a, 'c, u8>
+where
+    'c: 'a,
+{
+    move |input: &'a [u8], context: &'c mut AmlContext| match input.first() {
+        Some(&byte) => Ok((&input[1..], context, byte)),
+        None => Err((input, context, AmlError::UnexpectedEndOfStream)),
     }
 }
 
-pub fn take_u16<'a>() -> impl Parser<'a, u16> {
-    move |input: &'a [u8]| {
+pub fn take_u16<'a, 'c>() -> impl Parser<'a, 'c, u16>
+where
+    'c: 'a,
+{
+    move |input: &'a [u8], context: &'c mut AmlContext| {
         if input.len() < 2 {
-            return Err((input, AmlError::UnexpectedEndOfStream));
+            return Err((input, context, AmlError::UnexpectedEndOfStream));
         }
 
-        Ok((&input[2..], input[0] as u16 + ((input[1] as u16) << 8)))
+        Ok((&input[2..], context, input[0] as u16 + ((input[1] as u16) << 8)))
     }
 }
 
-pub fn take_u32<'a>() -> impl Parser<'a, u32> {
-    move |input: &'a [u8]| {
+pub fn take_u32<'a, 'c>() -> impl Parser<'a, 'c, u32>
+where
+    'c: 'a,
+{
+    move |input: &'a [u8], context: &'c mut AmlContext| {
         if input.len() < 4 {
-            return Err((input, AmlError::UnexpectedEndOfStream));
+            return Err((input, context, AmlError::UnexpectedEndOfStream));
         }
 
         Ok((
             &input[4..],
+            context,
             input[0] as u32
                 + ((input[1] as u32) << 8)
                 + ((input[2] as u32) << 16)
@@ -92,14 +107,18 @@ pub fn take_u32<'a>() -> impl Parser<'a, u32> {
     }
 }
 
-pub fn take_u64<'a>() -> impl Parser<'a, u64> {
-    move |input: &'a [u8]| {
+pub fn take_u64<'a, 'c>() -> impl Parser<'a, 'c, u64>
+where
+    'c: 'a,
+{
+    move |input: &'a [u8], context: &'c mut AmlContext| {
         if input.len() < 8 {
-            return Err((input, AmlError::UnexpectedEndOfStream));
+            return Err((input, context, AmlError::UnexpectedEndOfStream));
         }
 
         Ok((
             &input[8..],
+            context,
             input[0] as u64
                 + ((input[1] as u64) << 8)
                 + ((input[2] as u64) << 16)
@@ -112,178 +131,201 @@ pub fn take_u64<'a>() -> impl Parser<'a, u64> {
     }
 }
 
-pub fn take_n<'a>(n: usize) -> impl Parser<'a, &'a [u8]> {
-    move |input: &'a [u8]| {
+pub fn take_n<'a, 'c>(n: usize) -> impl Parser<'a, 'c, &'a [u8]>
+where
+    'c: 'a,
+{
+    move |input: &'a [u8], context| {
         if input.len() < n {
-            return Err((input, AmlError::UnexpectedEndOfStream));
+            return Err((input, context, AmlError::UnexpectedEndOfStream));
         }
 
         let (result, new_input) = input.split_at(n);
-        Ok((new_input, result))
+        Ok((new_input, context, result))
     }
 }
 
 // TODO: can we use const generics (e.g. [R; N]) to avoid allocating?
-pub fn n_of<'a, P, R>(parser: P, n: usize) -> impl Parser<'a, Vec<R>>
+pub fn n_of<'a, 'c, P, R>(parser: P, n: usize) -> impl Parser<'a, 'c, Vec<R>>
 where
-    P: Parser<'a, R>,
+    'c: 'a,
+    P: Parser<'a, 'c, R>,
 {
-    move |input| {
+    // TODO: can we write this more nicely?
+    move |mut input, mut context| {
         let mut results = Vec::with_capacity(n);
-        let mut new_input = input;
 
         for _ in 0..n {
-            let (after_input, result) = match parser.parse(new_input) {
-                Ok((input, result)) => (input, result),
-                Err((_, err)) => return Err((input, err)),
+            let (new_input, new_context, result) = match parser.parse(input, context) {
+                Ok((input, context, result)) => (input, context, result),
+                Err((_, context, err)) => return Err((input, context, err)),
             };
             results.push(result);
-            new_input = after_input;
+            input = new_input;
+            context = new_context;
         }
 
-        Ok((new_input, results))
+        Ok((input, context, results))
     }
 }
 
-pub fn consume<'a, F>(condition: F) -> impl Parser<'a, u8>
+pub fn consume<'a, 'c, F>(condition: F) -> impl Parser<'a, 'c, u8>
 where
+    'c: 'a,
     F: Fn(u8) -> bool,
 {
-    move |input: &'a [u8]| match input.first() {
-        Some(&byte) if condition(byte) => Ok((&input[1..], byte)),
-        Some(&byte) => Err((input, AmlError::UnexpectedByte(byte))),
-        None => Err((input, AmlError::UnexpectedEndOfStream)),
+    move |input: &'a [u8], context: &'c mut AmlContext| match input.first() {
+        Some(&byte) if condition(byte) => Ok((&input[1..], context, byte)),
+        Some(&byte) => Err((input, context, AmlError::UnexpectedByte(byte))),
+        None => Err((input, context, AmlError::UnexpectedEndOfStream)),
     }
 }
 
-pub fn comment_scope<'a, P, R>(scope_name: &'a str, parser: P) -> impl Parser<'a, R>
+pub fn comment_scope<'a, 'c, P, R>(scope_name: &'a str, parser: P) -> impl Parser<'a, 'c, R>
 where
+    'c: 'a,
     R: core::fmt::Debug,
-    P: Parser<'a, R>,
+    P: Parser<'a, 'c, R>,
 {
-    move |input| {
+    move |input, context| {
         trace!("--> {}", scope_name);
         // Return if the parse fails, so we don't print the tail. Makes it easier to debug.
-        let (new_input, result) = parser.parse(input)?;
+        let (new_input, context, result) = parser.parse(input, context)?;
         trace!("<-- {}({:?})", scope_name, result);
-        Ok((new_input, result))
+        Ok((new_input, context, result))
     }
 }
 
-pub struct Or<'a, P1, P2, R>
+pub struct Or<'a, 'c, P1, P2, R>
 where
-    P1: Parser<'a, R>,
-    P2: Parser<'a, R>,
+    'c: 'a,
+    P1: Parser<'a, 'c, R>,
+    P2: Parser<'a, 'c, R>,
 {
     p1: P1,
     p2: P2,
-    _phantom: PhantomData<&'a R>,
+    _phantom: PhantomData<(&'a R, &'c ())>,
 }
 
-impl<'a, P1, P2, R> Parser<'a, R> for Or<'a, P1, P2, R>
+impl<'a, 'c, P1, P2, R> Parser<'a, 'c, R> for Or<'a, 'c, P1, P2, R>
 where
-    P1: Parser<'a, R>,
-    P2: Parser<'a, R>,
+    'c: 'a,
+    P1: Parser<'a, 'c, R>,
+    P2: Parser<'a, 'c, R>,
 {
-    fn parse(&self, input: &'a [u8]) -> ParseResult<'a, R> {
-        match self.p1.parse(input) {
-            Ok(result) => return Ok(result),
-            Err(_) => (),
-        }
+    fn parse(&self, input: &'a [u8], context: &'c mut AmlContext) -> ParseResult<'a, 'c, R> {
+        let context = match self.p1.parse(input, context) {
+            Ok(parse_result) => return Ok(parse_result),
+            Err((_, context, _)) => context,
+        };
 
-        self.p2.parse(input)
+        self.p2.parse(input, context)
     }
 }
 
-pub struct Map<'a, P, F, R, A>
+pub struct Map<'a, 'c, P, F, R, A>
 where
-    P: Parser<'a, R>,
+    'c: 'a,
+    P: Parser<'a, 'c, R>,
     F: Fn(R) -> A,
 {
     parser: P,
     map_fn: F,
-    _phantom: PhantomData<&'a (R, A)>,
+    _phantom: PhantomData<(&'a (R, A), &'c ())>,
 }
 
-impl<'a, P, F, R, A> Parser<'a, A> for Map<'a, P, F, R, A>
+impl<'a, 'c, P, F, R, A> Parser<'a, 'c, A> for Map<'a, 'c, P, F, R, A>
 where
-    P: Parser<'a, R>,
+    'c: 'a,
+    P: Parser<'a, 'c, R>,
     F: Fn(R) -> A,
 {
-    fn parse(&self, input: &'a [u8]) -> ParseResult<'a, A> {
-        self.parser.parse(input).map(|(new_input, result)| (new_input, (self.map_fn)(result)))
+    fn parse(&self, input: &'a [u8], context: &'c mut AmlContext) -> ParseResult<'a, 'c, A> {
+        self.parser
+            .parse(input, context)
+            .map(|(new_input, new_context, result)| (new_input, new_context, (self.map_fn)(result)))
     }
 }
 
-pub struct DiscardResult<'a, P, R>
+pub struct DiscardResult<'a, 'c, P, R>
 where
-    P: Parser<'a, R>,
+    'c: 'a,
+    P: Parser<'a, 'c, R>,
 {
     parser: P,
-    _phantom: PhantomData<&'a R>,
+    _phantom: PhantomData<(&'a R, &'c ())>,
 }
 
-impl<'a, P, R> Parser<'a, ()> for DiscardResult<'a, P, R>
+impl<'a, 'c, P, R> Parser<'a, 'c, ()> for DiscardResult<'a, 'c, P, R>
 where
-    P: Parser<'a, R>,
+    'c: 'a,
+    P: Parser<'a, 'c, R>,
 {
-    fn parse(&self, input: &'a [u8]) -> ParseResult<'a, ()> {
-        self.parser.parse(input).map(|(new_input, _)| (new_input, ()))
+    fn parse(&self, input: &'a [u8], context: &'c mut AmlContext) -> ParseResult<'a, 'c, ()> {
+        self.parser
+            .parse(input, context)
+            .map(|(new_input, new_context, _)| (new_input, new_context, ()))
     }
 }
 
-pub struct Then<'a, P1, P2, R1, R2>
+pub struct Then<'a, 'c, P1, P2, R1, R2>
 where
-    P1: Parser<'a, R1>,
-    P2: Parser<'a, R2>,
+    'c: 'a,
+    P1: Parser<'a, 'c, R1>,
+    P2: Parser<'a, 'c, R2>,
 {
     p1: P1,
     p2: P2,
-    _phantom: PhantomData<&'a (R1, R2)>,
+    _phantom: PhantomData<(&'a (R1, R2), &'c ())>,
 }
 
-impl<'a, P1, P2, R1, R2> Parser<'a, (R1, R2)> for Then<'a, P1, P2, R1, R2>
+impl<'a, 'c, P1, P2, R1, R2> Parser<'a, 'c, (R1, R2)> for Then<'a, 'c, P1, P2, R1, R2>
 where
-    P1: Parser<'a, R1>,
-    P2: Parser<'a, R2>,
+    'c: 'a,
+    P1: Parser<'a, 'c, R1>,
+    P2: Parser<'a, 'c, R2>,
 {
-    fn parse(&self, input: &'a [u8]) -> ParseResult<'a, (R1, R2)> {
-        self.p1.parse(input).and_then(|(next_input, result_a)| {
-            self.p2
-                .parse(next_input)
-                .map(|(final_input, result_b)| (final_input, (result_a, result_b)))
+    fn parse(&self, input: &'a [u8], context: &'c mut AmlContext) -> ParseResult<'a, 'c, (R1, R2)> {
+        self.p1.parse(input, context).and_then(|(next_input, context, result_a)| {
+            self.p2.parse(next_input, context).map(|(final_input, context, result_b)| {
+                (final_input, context, (result_a, result_b))
+            })
         })
     }
 }
 
-pub struct Feed<'a, P1, P2, F, R1, R2>
+pub struct Feed<'a, 'c, P1, P2, F, R1, R2>
 where
-    P1: Parser<'a, R1>,
-    P2: Parser<'a, R2>,
+    'c: 'a,
+    P1: Parser<'a, 'c, R1>,
+    P2: Parser<'a, 'c, R2>,
     F: Fn(R1) -> P2,
 {
     parser: P1,
     producer_fn: F,
-    _phantom: PhantomData<&'a (R1, R2)>,
+    _phantom: PhantomData<(&'a (R1, R2), &'c ())>,
 }
 
-impl<'a, P1, P2, F, R1, R2> Parser<'a, R2> for Feed<'a, P1, P2, F, R1, R2>
+impl<'a, 'c, P1, P2, F, R1, R2> Parser<'a, 'c, R2> for Feed<'a, 'c, P1, P2, F, R1, R2>
 where
-    P1: Parser<'a, R1>,
-    P2: Parser<'a, R2>,
+    'c: 'a,
+    P1: Parser<'a, 'c, R1>,
+    P2: Parser<'a, 'c, R2>,
     F: Fn(R1) -> P2,
 {
-    fn parse(&self, input: &'a [u8]) -> ParseResult<'a, R2> {
-        let (input, first_result) = self.parser.parse(input)?;
+    fn parse(&self, input: &'a [u8], context: &'c mut AmlContext) -> ParseResult<'a, 'c, R2> {
+        let (input, context, first_result) = self.parser.parse(input, context)?;
 
         // We can now produce the second parser, and parse using that.
         let second_parser = (self.producer_fn)(first_result);
-        second_parser.parse(input)
+        second_parser.parse(input, context)
     }
 }
 
 /// Takes a number of parsers, and tries to apply each one to the input in order. Returns the
 /// result of the first one that succeeds, or fails if all of them fail.
+// TODO: maybe this should emit a custom error at the end? "None of these parsers could parse
+// this?" Or maybe just a specific UnexpectedByte?
 pub macro choice {
     ($first_parser: expr) => {
         $first_parser
@@ -304,25 +346,48 @@ mod tests {
 
     #[test]
     fn test_take_n() {
-        check_err!(take_n(1).parse(&[]), AmlError::UnexpectedEndOfStream, &[]);
-        check_err!(take_n(2).parse(&[0xf5]), AmlError::UnexpectedEndOfStream, &[0xf5]);
+        let mut context = AmlContext::new();
+        check_err!(take_n(1).parse(&[], &mut context), AmlError::UnexpectedEndOfStream, &[]);
+        check_err!(
+            take_n(2).parse(&[0xf5], &mut context),
+            AmlError::UnexpectedEndOfStream,
+            &[0xf5]
+        );
 
-        check_ok!(take_n(1).parse(&[0xff]), &[0xff], &[]);
-        check_ok!(take_n(1).parse(&[0xff, 0xf8]), &[0xff], &[0xf8]);
-        check_ok!(take_n(2).parse(&[0xff, 0xf8]), &[0xff, 0xf8], &[]);
+        check_ok!(take_n(1).parse(&[0xff], &mut context), &[0xff], &[]);
+        check_ok!(take_n(1).parse(&[0xff, 0xf8], &mut context), &[0xff], &[0xf8]);
+        check_ok!(take_n(2).parse(&[0xff, 0xf8], &mut context), &[0xff, 0xf8], &[]);
     }
 
     #[test]
     fn test_take_ux() {
-        check_err!(take_u16().parse(&[0x34]), AmlError::UnexpectedEndOfStream, &[0x34]);
-        check_ok!(take_u16().parse(&[0x34, 0x12]), 0x1234, &[]);
+        let mut context = AmlContext::new();
+        check_err!(
+            take_u16().parse(&[0x34], &mut context),
+            AmlError::UnexpectedEndOfStream,
+            &[0x34]
+        );
+        check_ok!(take_u16().parse(&[0x34, 0x12], &mut context), 0x1234, &[]);
 
-        check_err!(take_u32().parse(&[0x34, 0x12]), AmlError::UnexpectedEndOfStream, &[0x34, 0x12]);
-        check_ok!(take_u32().parse(&[0x34, 0x12, 0xf4, 0xc3, 0x3e]), 0xc3f41234, &[0x3e]);
-
-        check_err!(take_u64().parse(&[0x34]), AmlError::UnexpectedEndOfStream, &[0x34]);
+        check_err!(
+            take_u32().parse(&[0x34, 0x12], &mut context),
+            AmlError::UnexpectedEndOfStream,
+            &[0x34, 0x12]
+        );
         check_ok!(
-            take_u64().parse(&[0x34, 0x12, 0x35, 0x76, 0xd4, 0x43, 0xa3, 0xb6, 0xff, 0x00]),
+            take_u32().parse(&[0x34, 0x12, 0xf4, 0xc3, 0x3e], &mut context),
+            0xc3f41234,
+            &[0x3e]
+        );
+
+        check_err!(
+            take_u64().parse(&[0x34], &mut context),
+            AmlError::UnexpectedEndOfStream,
+            &[0x34]
+        );
+        check_ok!(
+            take_u64()
+                .parse(&[0x34, 0x12, 0x35, 0x76, 0xd4, 0x43, 0xa3, 0xb6, 0xff, 0x00], &mut context),
             0xb6a343d476351234,
             &[0xff, 0x00]
         );

--- a/aml_parser/src/pkg_length.rs
+++ b/aml_parser/src/pkg_length.rs
@@ -64,7 +64,7 @@ where
         }
 
         let (new_input, context, length): (&[u8], &mut AmlContext, u32) =
-            match take_n(byte_count as usize).parse(new_input, context) {
+            match take_n(byte_count as u32).parse(new_input, context) {
                 Ok((new_input, context, bytes)) => {
                     let initial_length = u32::from(lead_byte.get_bits(0..4));
                     (

--- a/aml_parser/src/pkg_length.rs
+++ b/aml_parser/src/pkg_length.rs
@@ -3,7 +3,6 @@ use crate::{
     AmlError,
 };
 use bit_field::BitField;
-use log::trace;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct PkgLength {
@@ -49,8 +48,6 @@ pub fn raw_pkg_length<'a>() -> impl Parser<'a, u32> {
      * The length encoded by the PkgLength includes the number of bytes used to encode it.
      */
     move |input: &'a [u8]| {
-        let starting_len = input.len() as u32;
-
         let (new_input, lead_byte) = take().parse(input)?;
         let byte_count = lead_byte.get_bits(6..8);
 

--- a/aml_parser/src/pkg_length.rs
+++ b/aml_parser/src/pkg_length.rs
@@ -1,0 +1,70 @@
+use crate::{
+    parser::{take, take_n, Parser},
+    AmlError,
+};
+use bit_field::BitField;
+use log::trace;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct PkgLength(u32);
+
+pub fn pkg_length<'a>() -> impl Parser<'a, PkgLength> {
+    /*
+     * PkgLength := PkgLeadByte |
+     * <PkgLeadByte ByteData> |
+     * <PkgLeadByte ByteData ByteData> |
+     * <PkgLeadByte ByteData ByteData ByteData>
+     *
+     * The length encoded by the PkgLength includes the number of bytes used to encode it.
+     */
+    move |input: &'a [u8]| {
+        let (new_input, lead_byte) = take().parse(input)?;
+        let byte_count = lead_byte.get_bits(6..8);
+
+        if byte_count == 0 {
+            let length = u32::from(lead_byte.get_bits(0..6));
+            return Ok((new_input, PkgLength(length)));
+        }
+
+        let (new_input, length): (&[u8], u32) = match take_n(byte_count as usize).parse(new_input) {
+            Ok((new_input, bytes)) => {
+                let initial_length = u32::from(lead_byte.get_bits(0..4));
+                (
+                    new_input,
+                    bytes.iter().enumerate().fold(initial_length, |length, (i, &byte)| {
+                        length + (u32::from(byte) << (4 + i * 8))
+                    }),
+                )
+            }
+
+            /*
+             * The stream was too short. We return an error, making sure to return the
+             * *original* stream (that we haven't consumed any of).
+             */
+            Err((_, err)) => return Err((input, AmlError::UnexpectedEndOfStream)),
+        };
+
+        Ok((new_input, PkgLength(length)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_utils::*, AmlError};
+
+    #[test]
+    fn test_pkg_length() {
+        check_err!(pkg_length().parse(&[]), AmlError::UnexpectedEndOfStream, &[]);
+        check_ok!(pkg_length().parse(&[0x00]), PkgLength(0), &[]);
+        check_ok!(pkg_length().parse(&[0x05, 0xf5, 0x7f]), PkgLength(5), &[0xf5, 0x7f]);
+        check_ok!(pkg_length().parse(&[0b01000101, 0x14]), PkgLength(325), &[]);
+        check_ok!(pkg_length().parse(&[0b01000111, 0x14, 0x46]), PkgLength(327), &[0x46]);
+        check_ok!(pkg_length().parse(&[0b10000111, 0x14, 0x46]), PkgLength(287047), &[]);
+        check_err!(
+            pkg_length().parse(&[0b11000000, 0xff, 0x4f]),
+            AmlError::UnexpectedEndOfStream,
+            &[0b11000000, 0xff, 0x4f]
+        );
+    }
+}

--- a/aml_parser/src/pkg_length.rs
+++ b/aml_parser/src/pkg_length.rs
@@ -5,8 +5,7 @@ use crate::{
 use bit_field::BitField;
 use log::trace;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct PkgLength(u32);
+pub type PkgLength = u32;
 
 pub fn pkg_length<'a>() -> impl Parser<'a, PkgLength> {
     /*
@@ -23,7 +22,7 @@ pub fn pkg_length<'a>() -> impl Parser<'a, PkgLength> {
 
         if byte_count == 0 {
             let length = u32::from(lead_byte.get_bits(0..6));
-            return Ok((new_input, PkgLength(length)));
+            return Ok((new_input, length));
         }
 
         let (new_input, length): (&[u8], u32) = match take_n(byte_count as usize).parse(new_input) {
@@ -44,7 +43,7 @@ pub fn pkg_length<'a>() -> impl Parser<'a, PkgLength> {
             Err((_, err)) => return Err((input, AmlError::UnexpectedEndOfStream)),
         };
 
-        Ok((new_input, PkgLength(length)))
+        Ok((new_input, length))
     }
 }
 
@@ -56,11 +55,11 @@ mod tests {
     #[test]
     fn test_pkg_length() {
         check_err!(pkg_length().parse(&[]), AmlError::UnexpectedEndOfStream, &[]);
-        check_ok!(pkg_length().parse(&[0x00]), PkgLength(0), &[]);
-        check_ok!(pkg_length().parse(&[0x05, 0xf5, 0x7f]), PkgLength(5), &[0xf5, 0x7f]);
-        check_ok!(pkg_length().parse(&[0b01000101, 0x14]), PkgLength(325), &[]);
-        check_ok!(pkg_length().parse(&[0b01000111, 0x14, 0x46]), PkgLength(327), &[0x46]);
-        check_ok!(pkg_length().parse(&[0b10000111, 0x14, 0x46]), PkgLength(287047), &[]);
+        check_ok!(pkg_length().parse(&[0x00]), 0, &[]);
+        check_ok!(pkg_length().parse(&[0x05, 0xf5, 0x7f]), 5, &[0xf5, 0x7f]);
+        check_ok!(pkg_length().parse(&[0b01000101, 0x14]), 325, &[]);
+        check_ok!(pkg_length().parse(&[0b01000111, 0x14, 0x46]), 327, &[0x46]);
+        check_ok!(pkg_length().parse(&[0b10000111, 0x14, 0x46]), 287047, &[]);
         check_err!(
             pkg_length().parse(&[0b11000000, 0xff, 0x4f]),
             AmlError::UnexpectedEndOfStream,

--- a/aml_parser/src/pkg_length.rs
+++ b/aml_parser/src/pkg_length.rs
@@ -5,9 +5,41 @@ use crate::{
 use bit_field::BitField;
 use log::trace;
 
-pub type PkgLength = u32;
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct PkgLength {
+    pub raw_length: u32,
+    /// The distance from the end of the structure this `PkgLength` refers to, and the end of the
+    /// stream.
+    pub end_offset: u32,
+}
+
+impl PkgLength {
+    pub fn from_raw_length(stream: &[u8], raw_length: u32) -> PkgLength {
+        PkgLength { raw_length, end_offset: stream.len() as u32 - raw_length }
+    }
+
+    /// Returns `true` if the given stream is still within the structure this `PkgLength` refers
+    /// to.
+    pub fn still_parsing(&self, stream: &[u8]) -> bool {
+        stream.len() as u32 > self.end_offset
+    }
+}
 
 pub fn pkg_length<'a>() -> impl Parser<'a, PkgLength> {
+    move |input: &'a [u8]| {
+        let (new_input, raw_length) = raw_pkg_length().parse(input)?;
+
+        /*
+         * NOTE: we use the original input here, because `raw_length` includes the length of the
+         * `PkgLength`.
+         */
+        Ok((new_input, PkgLength::from_raw_length(input, raw_length)))
+    }
+}
+
+/// Parses a `PkgLength` and returns the *raw length*. If you want an instance of `PkgLength`, use
+/// `pkg_length` instead.
+pub fn raw_pkg_length<'a>() -> impl Parser<'a, u32> {
     /*
      * PkgLength := PkgLeadByte |
      * <PkgLeadByte ByteData> |
@@ -17,6 +49,8 @@ pub fn pkg_length<'a>() -> impl Parser<'a, PkgLength> {
      * The length encoded by the PkgLength includes the number of bytes used to encode it.
      */
     move |input: &'a [u8]| {
+        let starting_len = input.len() as u32;
+
         let (new_input, lead_byte) = take().parse(input)?;
         let byte_count = lead_byte.get_bits(6..8);
 
@@ -52,18 +86,43 @@ mod tests {
     use super::*;
     use crate::{test_utils::*, AmlError};
 
+    fn test_correct_pkglength(stream: &[u8], expected_raw_length: u32, expected_leftover: &[u8]) {
+        check_ok!(
+            pkg_length().parse(stream),
+            PkgLength::from_raw_length(stream, expected_raw_length),
+            &expected_leftover
+        );
+    }
+
+    #[test]
+    fn test_raw_pkg_length() {
+        check_ok!(raw_pkg_length().parse(&[0b01000101, 0x14]), 325, &[]);
+        check_ok!(raw_pkg_length().parse(&[0b01000111, 0x14, 0x46]), 327, &[0x46]);
+        check_ok!(raw_pkg_length().parse(&[0b10000111, 0x14, 0x46]), 287047, &[]);
+    }
+
     #[test]
     fn test_pkg_length() {
         check_err!(pkg_length().parse(&[]), AmlError::UnexpectedEndOfStream, &[]);
-        check_ok!(pkg_length().parse(&[0x00]), 0, &[]);
-        check_ok!(pkg_length().parse(&[0x05, 0xf5, 0x7f]), 5, &[0xf5, 0x7f]);
-        check_ok!(pkg_length().parse(&[0b01000101, 0x14]), 325, &[]);
-        check_ok!(pkg_length().parse(&[0b01000111, 0x14, 0x46]), 327, &[0x46]);
-        check_ok!(pkg_length().parse(&[0b10000111, 0x14, 0x46]), 287047, &[]);
+        test_correct_pkglength(&[0x00], 0, &[]);
+        test_correct_pkglength(
+            &[0x05, 0xf5, 0x7f, 0x3e, 0x54, 0x03],
+            5,
+            &[0xf5, 0x7f, 0x3e, 0x54, 0x03],
+        );
         check_err!(
             pkg_length().parse(&[0b11000000, 0xff, 0x4f]),
             AmlError::UnexpectedEndOfStream,
             &[0b11000000, 0xff, 0x4f]
         );
+    }
+
+    #[test]
+    #[should_panic]
+    fn not_enough_stream() {
+        /*
+         * TODO: Ideally, this shouldn't panic the parser, but return a `UnexpectedEndOfStream`.
+         */
+        test_correct_pkglength(&[0x05, 0xf5], 5, &[0xf5]);
     }
 }

--- a/aml_parser/src/pkg_length.rs
+++ b/aml_parser/src/pkg_length.rs
@@ -71,7 +71,7 @@ pub fn raw_pkg_length<'a>() -> impl Parser<'a, u32> {
              * The stream was too short. We return an error, making sure to return the
              * *original* stream (that we haven't consumed any of).
              */
-            Err((_, err)) => return Err((input, AmlError::UnexpectedEndOfStream)),
+            Err(_) => return Err((input, AmlError::UnexpectedEndOfStream)),
         };
 
         Ok((new_input, length))

--- a/aml_parser/src/term_object.rs
+++ b/aml_parser/src/term_object.rs
@@ -1,11 +1,12 @@
 use crate::{
-    name_object::name_string,
-    opcode::{opcode, SCOPE_OP},
-    parser::{choice, comment, comment_scope, take_n, ParseResult, Parser},
+    name_object::{name_seg, name_string},
+    opcode::{self, ext_opcode, opcode},
+    parser::{choice, comment_scope, take, take_u16, take_u32, take_u64, ParseResult, Parser},
     pkg_length::{pkg_length, PkgLength},
     value::{AmlValue, FieldFlags},
-    AmlNamespace,
+    AmlError,
 };
+use alloc::string::String;
 use log::{debug, trace};
 
 /// `TermList`s are usually found within explicit-length objects (so they have a `PkgLength`
@@ -30,14 +31,14 @@ pub fn term_object<'a>() -> impl Parser<'a, ()> {
      * TermObj := NamespaceModifierObj | NamedObj | Type1Opcode | Type2Opcode
      * NamespaceModifierObj := DefAlias | DefName | DefScope
      */
-    comment_scope("TermObj", choice!(def_scope()))
+    comment_scope("TermObj", choice!(def_scope(), def_op_region(), def_field()))
 }
 
 pub fn def_scope<'a>() -> impl Parser<'a, ()> {
     /*
      * DefScope := 0x10 PkgLength NameString TermList
      */
-    opcode(SCOPE_OP)
+    opcode(opcode::SCOPE_OP)
         .then(comment_scope(
             "DefScope",
             pkg_length().then(name_string()).feed(move |(pkg_length, name)| {
@@ -47,6 +48,127 @@ pub fn def_scope<'a>() -> impl Parser<'a, ()> {
         ))
         .discard_result()
 }
+
+pub fn def_op_region<'a>() -> impl Parser<'a, ()> {
+    /*
+     * DefOpRegion := ExtOpPrefix 0x80 NameString RegionSpace RegionOffset RegionLen
+     * RegionSpace := ByteData (where 0x00      = SystemMemory
+     *                                0x01      = SystemIO
+     *                                0x02      = PciConfig
+     *                                0x03      = EmbeddedControl
+     *                                0x04      = SMBus
+     *                                0x05      = SystemCMOS
+     *                                0x06      = PciBarTarget
+     *                                0x07      = IPMI
+     *                                0x08      = GeneralPurposeIO
+     *                                0x09      = GenericSerialBus
+     *                                0x80-0xff = OEM Defined)
+     * ByteData := 0x00 - 0xff
+     * RegionOffset := TermArg => Integer
+     * RegionLen := TermArg => Integer
+     */
+    ext_opcode(opcode::EXT_OP_REGION_OP)
+        .then(comment_scope(
+            "DefOpRegion",
+            name_string().then(take()).then(term_arg()).then(term_arg()).map(
+                |(((name, space), offset), region_len)| {
+                    trace!("Op region: {}, {}, {:?}, {:?}", name, space, offset, region_len);
+                    ()
+                },
+            ),
+        ))
+        .discard_result()
+}
+
+pub fn def_field<'a>() -> impl Parser<'a, ()> {
+    /*
+     * DefField = ExtOpPrefix 0x81 PkgLength NameString FieldFlags FieldList
+     * FieldFlags := ByteData
+     */
+    ext_opcode(opcode::EXT_FIELD_OP)
+        .then(comment_scope(
+            "DefField",
+            pkg_length().then(name_string()).then(take()).feed(
+                |((list_length, region_name), flags)| {
+                    move |mut input: &'a [u8]| -> ParseResult<'a, ()> {
+                        /*
+                         * FieldList := Nothing | <FieldElement FieldList>
+                         */
+                        // TODO: can this pattern be expressed as a combinator
+                        while list_length.still_parsing(input) {
+                            let (new_input, ()) =
+                                field_element(&region_name, FieldFlags::new(flags)).parse(input)?;
+                            input = new_input;
+                        }
+
+                        Ok((input, ()))
+                    }
+                },
+            ),
+        ))
+        .discard_result()
+}
+
+pub fn field_element<'a>(region_name: &String, flags: FieldFlags) -> impl Parser<'a, ()> {
+    /*
+     * FieldElement := NamedField | ReservedField | AccessField | ExtendedAccessField |
+     *                 ConnectField
+     * NamedField := NameSeg PkgLength
+     * ReservedField := 0x00 PkgLength
+     * AccessField := 0x01 AccessType AccessAttrib
+     * ConnectField := <0x02 NameString> | <0x02 BufferData>
+     * ExtendedAccessField := 0x03 AccessType ExtendedAccessAttrib AccessLength
+     *
+     * AccessType := ByteData
+     * AccessAttrib := ByteData
+     *
+     * XXX: The spec says a ConnectField can be <0x02 BufferData>, but BufferData isn't an AML
+     * object (it seems to be defined in ASL). We treat BufferData as if it was encoded like
+     * DefBuffer, and this seems to work so far.
+     */
+    // TODO: replace these maps with `with_context` and register the fields in the namespace
+    // TODO: parse ConnectField and ExtendedAccessField
+    let reserved_field =
+        opcode(opcode::RESERVED_FIELD).then(pkg_length()).map(|((), pkg_length)| {
+            trace!("Adding reserved field with length: {}", pkg_length.raw_length);
+        });
+
+    let access_field = opcode(opcode::ACCESS_FIELD).then(take()).then(take()).map(
+        |(((), access_type), access_attrib)| {
+            trace!(
+                "Adding access field with access_type: {}, access_attrib: {}",
+                access_type,
+                access_attrib
+            );
+        },
+    );
+
+    let named_field = name_seg().then(pkg_length()).map(|(name, length)| {
+        trace!("Named field with name {} and length {}", name.as_str(), length.raw_length);
+    });
+
+    choice!(reserved_field, access_field, named_field)
+}
+
+pub fn term_arg<'a>() -> impl Parser<'a, AmlValue> {
+    /*
+     * TermArg := Type2Opcode | DataObject | ArgObj | LocalObj
+     */
+    // TODO: this doesn't yet parse Term2Opcode, ArgObj, or LocalObj
+    comment_scope("TermArg", choice!(data_object()))
+}
+
+pub fn data_object<'a>() -> impl Parser<'a, AmlValue> {
+    /*
+     * DataObject := DefPackage | DefVarPackage | ComputationalData
+     *
+     * The order of the parsers are important here, as DefPackage and DefVarPackage can be
+     * accidently parsed as ComputationalDatas.
+     */
+    // TODO: this doesn't yet parse DefPackage or DefVarPackage
+    comment_scope("DataObject", choice!(computational_data()))
+}
+
 pub fn computational_data<'a>() -> impl Parser<'a, AmlValue> {
     /*
      * ComputationalData := ByteConst | WordConst | DWordConst | QWordConst | String |

--- a/aml_parser/src/term_object.rs
+++ b/aml_parser/src/term_object.rs
@@ -21,7 +21,6 @@ use crate::{
 };
 use alloc::{string::String, vec::Vec};
 use core::str;
-use log::trace;
 
 /// `TermList`s are usually found within explicit-length objects (so they have a `PkgLength`
 /// elsewhere in the structure), so this takes a number of bytes to parse.

--- a/aml_parser/src/term_object.rs
+++ b/aml_parser/src/term_object.rs
@@ -103,7 +103,7 @@ where
                 |(name, data_ref_object), context| {
                     // TODO: add to namespace
                     trace!("Defined name: {}", name);
-                    ((), context)
+                    (Ok(()), context)
                 },
             ),
         ))
@@ -125,16 +125,16 @@ where
                 .map_with_context(|(length, name), context| {
                     // TODO: change scope in `context`
                     trace!("Moving to scope: {:?}", name);
-                    ((length, name), context)
+                    (Ok((length, name, previous_scope)), context)
                 })
                 .feed(move |(pkg_length, name)| {
                     trace!("Scope with name: {}, length: {:?}", name, pkg_length);
                     term_list(pkg_length).map(move |_| Ok(name.clone()))
                 })
-                .map_with_context(|name, context| {
+                .map_with_context(|(name, previous_scope), context| {
                     // TODO: remove scope
                     trace!("Exiting scope: {}", name);
-                    ((), context)
+                    (Ok(()), context)
                 }),
         ))
         .discard_result()
@@ -168,7 +168,7 @@ where
                 |(((name, space), offset), region_len), context| {
                     trace!("Op region: {}, {}, {:?}, {:?}", name, space, offset, region_len);
                     // TODO: add to namespace
-                    ((), context)
+                    (Ok(()), context)
                 },
             ),
         ))
@@ -247,14 +247,14 @@ where
                 access_attrib
             );
             // TODO: put it in the namespace
-            ((), context)
+            (Ok(()), context)
         },
     );
 
     let named_field = name_seg().then(pkg_length()).map_with_context(|(name, length), context| {
         trace!("Named field with name {} and length {}", name.as_str(), length.raw_length);
         // TODO: put it in the namespace
-        ((), context)
+        (Ok(()), context)
     });
 
     choice!(reserved_field, access_field, named_field)
@@ -288,7 +288,7 @@ where
                         flags,
                         code.len()
                     );
-                    ((), context)
+                    (Ok(()), context)
                 }),
         ))
         .discard_result()
@@ -312,7 +312,7 @@ where
                 .map_with_context(|(name, result), context| {
                     // TODO: add to namespace
                     trace!("Device with name: {}", name);
-                    ((), context)
+                    (Ok(()), context)
                 }),
         ))
         .discard_result()

--- a/aml_parser/src/term_object.rs
+++ b/aml_parser/src/term_object.rs
@@ -3,6 +3,7 @@ use crate::{
     opcode::{opcode, SCOPE_OP},
     parser::{choice, comment, comment_scope, take_n, ParseResult, Parser},
     pkg_length::{pkg_length, PkgLength},
+    value::{AmlValue, FieldFlags},
     AmlNamespace,
 };
 use log::{debug, trace};
@@ -43,4 +44,97 @@ pub fn def_scope<'a>() -> impl Parser<'a, ()> {
             }),
         ))
         .discard_result()
+}
+pub fn computational_data<'a>() -> impl Parser<'a, AmlValue> {
+    /*
+     * ComputationalData := ByteConst | WordConst | DWordConst | QWordConst | String |
+     *                      ConstObj | RevisionOp | DefBuffer
+     * ByteConst := 0x0a ByteData
+     * WordConst := 0x0b WordData
+     * DWordConst := 0x0c DWordData
+     * QWordConst := 0x0e QWordData
+     * String := 0x0d AsciiCharList NullChar
+     * ConstObj := ZeroOp(0x00) | OneOp(0x01) | OnesOp(0xff)
+     * RevisionOp := ExtOpPrefix(0x5b) 0x30
+     */
+    let const_parser = |input: &'a [u8]| {
+        let (new_input, op) = take().parse(input)?;
+
+        match op {
+            opcode::BYTE_CONST => {
+                take().map(|value| AmlValue::Integer(value as u64)).parse(new_input)
+            }
+            opcode::WORD_CONST => {
+                take_u16().map(|value| AmlValue::Integer(value as u64)).parse(new_input)
+            }
+            opcode::DWORD_CONST => {
+                take_u32().map(|value| AmlValue::Integer(value as u64)).parse(new_input)
+            }
+            opcode::QWORD_CONST => {
+                take_u64().map(|value| AmlValue::Integer(value)).parse(new_input)
+            }
+            // TODO: implement String
+            opcode::ZERO_OP => Ok((new_input, AmlValue::Integer(0))),
+            opcode::ONE_OP => Ok((new_input, AmlValue::Integer(1))),
+            opcode::ONES_OP => Ok((new_input, AmlValue::Integer(u64::max_value()))),
+
+            _ => Err((input, AmlError::UnexpectedByte(op))),
+        }
+    };
+
+    comment_scope(
+        "ComputationalData",
+        choice!(
+            ext_opcode(opcode::EXT_REVISION_OP)
+                .map(|_| AmlValue::Integer(crate::AML_INTERPRETER_REVISION)),
+            const_parser //TODO: parse DefBuffer here too
+        ),
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_utils::*;
+
+    #[test]
+    fn test_computational_data() {
+        check_ok!(
+            computational_data().parse(&[0x00, 0x34, 0x12]),
+            AmlValue::Integer(0),
+            &[0x34, 0x12]
+        );
+        check_ok!(
+            computational_data().parse(&[0x01, 0x18, 0xf3]),
+            AmlValue::Integer(1),
+            &[0x18, 0xf3]
+        );
+        check_ok!(
+            computational_data().parse(&[0xff, 0x98, 0xc3]),
+            AmlValue::Integer(u64::max_value()),
+            &[0x98, 0xc3]
+        );
+        check_ok!(
+            computational_data().parse(&[0x5b, 0x30]),
+            AmlValue::Integer(crate::AML_INTERPRETER_REVISION),
+            &[]
+        );
+        check_ok!(
+            computational_data().parse(&[0x0a, 0xf3, 0x35]),
+            AmlValue::Integer(0xf3),
+            &[0x35]
+        );
+        check_ok!(computational_data().parse(&[0x0b, 0xf3, 0x35]), AmlValue::Integer(0x35f3), &[]);
+        check_ok!(
+            computational_data().parse(&[0x0c, 0xf3, 0x35, 0x12, 0x65, 0xff, 0x00]),
+            AmlValue::Integer(0x651235f3),
+            &[0xff, 0x00]
+        );
+        check_ok!(
+            computational_data()
+                .parse(&[0x0e, 0xf3, 0x35, 0x12, 0x65, 0xff, 0x00, 0x67, 0xde, 0x28]),
+            AmlValue::Integer(0xde6700ff651235f3),
+            &[0x28]
+        );
+    }
 }

--- a/aml_parser/src/term_object.rs
+++ b/aml_parser/src/term_object.rs
@@ -4,6 +4,7 @@ use crate::{
     parser::{choice, comment_scope, take, take_u16, take_u32, take_u64, ParseResult, Parser},
     pkg_length::{pkg_length, PkgLength},
     value::{AmlValue, FieldFlags},
+    AmlContext,
     AmlError,
 };
 use alloc::string::String;
@@ -11,22 +12,29 @@ use log::{debug, trace};
 
 /// `TermList`s are usually found within explicit-length objects (so they have a `PkgLength`
 /// elsewhere in the structure), so this takes a number of bytes to parse.
-pub fn term_list<'a>(list_length: PkgLength) -> impl Parser<'a, ()> {
+pub fn term_list<'a, 'c>(list_length: PkgLength) -> impl Parser<'a, 'c, ()>
+where
+    'c: 'a,
+{
     /*
      * TermList := Nothing | <TermObj TermList>
      */
-    move |mut input: &'a [u8]| -> ParseResult<'a, ()> {
+    move |mut input: &'a [u8], mut context: &'c mut AmlContext| {
         while list_length.still_parsing(input) {
-            let (new_input, ()) = term_object().parse(input)?;
+            let (new_input, new_context, ()) = term_object().parse(input, context)?;
             input = new_input;
+            context = new_context;
         }
 
-        Ok((input, ()))
+        Ok((input, context, ()))
     }
 }
 
 // TODO: maybe return `AmlValue` on success
-pub fn term_object<'a>() -> impl Parser<'a, ()> {
+pub fn term_object<'a, 'c>() -> impl Parser<'a, 'c, ()>
+where
+    'c: 'a,
+{
     /*
      * TermObj := NamespaceModifierObj | NamedObj | Type1Opcode | Type2Opcode
      * NamespaceModifierObj := DefAlias | DefName | DefScope
@@ -34,7 +42,10 @@ pub fn term_object<'a>() -> impl Parser<'a, ()> {
     comment_scope("TermObj", choice!(def_scope(), def_op_region(), def_field()))
 }
 
-pub fn def_scope<'a>() -> impl Parser<'a, ()> {
+pub fn def_scope<'a, 'c>() -> impl Parser<'a, 'c, ()>
+where
+    'c: 'a,
+{
     /*
      * DefScope := 0x10 PkgLength NameString TermList
      */
@@ -49,7 +60,10 @@ pub fn def_scope<'a>() -> impl Parser<'a, ()> {
         .discard_result()
 }
 
-pub fn def_op_region<'a>() -> impl Parser<'a, ()> {
+pub fn def_op_region<'a, 'c>() -> impl Parser<'a, 'c, ()>
+where
+    'c: 'a,
+{
     /*
      * DefOpRegion := ExtOpPrefix 0x80 NameString RegionSpace RegionOffset RegionLen
      * RegionSpace := ByteData (where 0x00      = SystemMemory
@@ -80,7 +94,10 @@ pub fn def_op_region<'a>() -> impl Parser<'a, ()> {
         .discard_result()
 }
 
-pub fn def_field<'a>() -> impl Parser<'a, ()> {
+pub fn def_field<'a, 'c>() -> impl Parser<'a, 'c, ()>
+where
+    'c: 'a,
+{
     /*
      * DefField = ExtOpPrefix 0x81 PkgLength NameString FieldFlags FieldList
      * FieldFlags := ByteData
@@ -90,18 +107,22 @@ pub fn def_field<'a>() -> impl Parser<'a, ()> {
             "DefField",
             pkg_length().then(name_string()).then(take()).feed(
                 |((list_length, region_name), flags)| {
-                    move |mut input: &'a [u8]| -> ParseResult<'a, ()> {
+                    move |mut input: &'a [u8],
+                          mut context: &'c mut AmlContext|
+                          -> ParseResult<'a, 'c, ()> {
                         /*
                          * FieldList := Nothing | <FieldElement FieldList>
                          */
                         // TODO: can this pattern be expressed as a combinator
                         while list_length.still_parsing(input) {
-                            let (new_input, ()) =
-                                field_element(&region_name, FieldFlags::new(flags)).parse(input)?;
+                            let (new_input, new_context, ()) =
+                                field_element(&region_name, FieldFlags::new(flags))
+                                    .parse(input, context)?;
                             input = new_input;
+                            context = new_context;
                         }
 
-                        Ok((input, ()))
+                        Ok((input, context, ()))
                     }
                 },
             ),
@@ -109,7 +130,10 @@ pub fn def_field<'a>() -> impl Parser<'a, ()> {
         .discard_result()
 }
 
-pub fn field_element<'a>(region_name: &String, flags: FieldFlags) -> impl Parser<'a, ()> {
+pub fn field_element<'a, 'c>(region_name: &String, flags: FieldFlags) -> impl Parser<'a, 'c, ()>
+where
+    'c: 'a,
+{
     /*
      * FieldElement := NamedField | ReservedField | AccessField | ExtendedAccessField |
      *                 ConnectField
@@ -150,7 +174,10 @@ pub fn field_element<'a>(region_name: &String, flags: FieldFlags) -> impl Parser
     choice!(reserved_field, access_field, named_field)
 }
 
-pub fn term_arg<'a>() -> impl Parser<'a, AmlValue> {
+pub fn term_arg<'a, 'c>() -> impl Parser<'a, 'c, AmlValue>
+where
+    'c: 'a,
+{
     /*
      * TermArg := Type2Opcode | DataObject | ArgObj | LocalObj
      */
@@ -158,7 +185,10 @@ pub fn term_arg<'a>() -> impl Parser<'a, AmlValue> {
     comment_scope("TermArg", choice!(data_object()))
 }
 
-pub fn data_object<'a>() -> impl Parser<'a, AmlValue> {
+pub fn data_object<'a, 'c>() -> impl Parser<'a, 'c, AmlValue>
+where
+    'c: 'a,
+{
     /*
      * DataObject := DefPackage | DefVarPackage | ComputationalData
      *
@@ -169,7 +199,10 @@ pub fn data_object<'a>() -> impl Parser<'a, AmlValue> {
     comment_scope("DataObject", choice!(computational_data()))
 }
 
-pub fn computational_data<'a>() -> impl Parser<'a, AmlValue> {
+pub fn computational_data<'a, 'c>() -> impl Parser<'a, 'c, AmlValue>
+where
+    'c: 'a,
+{
     /*
      * ComputationalData := ByteConst | WordConst | DWordConst | QWordConst | String |
      *                      ConstObj | RevisionOp | DefBuffer
@@ -181,28 +214,28 @@ pub fn computational_data<'a>() -> impl Parser<'a, AmlValue> {
      * ConstObj := ZeroOp(0x00) | OneOp(0x01) | OnesOp(0xff)
      * RevisionOp := ExtOpPrefix(0x5b) 0x30
      */
-    let const_parser = |input: &'a [u8]| {
-        let (new_input, op) = take().parse(input)?;
+    let const_parser = |input: &'a [u8], context: &'c mut AmlContext| {
+        let (new_input, context, op) = take().parse(input, context)?;
 
         match op {
             opcode::BYTE_CONST => {
-                take().map(|value| AmlValue::Integer(value as u64)).parse(new_input)
+                take().map(|value| AmlValue::Integer(value as u64)).parse(new_input, context)
             }
             opcode::WORD_CONST => {
-                take_u16().map(|value| AmlValue::Integer(value as u64)).parse(new_input)
+                take_u16().map(|value| AmlValue::Integer(value as u64)).parse(new_input, context)
             }
             opcode::DWORD_CONST => {
-                take_u32().map(|value| AmlValue::Integer(value as u64)).parse(new_input)
+                take_u32().map(|value| AmlValue::Integer(value as u64)).parse(new_input, context)
             }
             opcode::QWORD_CONST => {
-                take_u64().map(|value| AmlValue::Integer(value)).parse(new_input)
+                take_u64().map(|value| AmlValue::Integer(value)).parse(new_input, context)
             }
             // TODO: implement String
-            opcode::ZERO_OP => Ok((new_input, AmlValue::Integer(0))),
-            opcode::ONE_OP => Ok((new_input, AmlValue::Integer(1))),
-            opcode::ONES_OP => Ok((new_input, AmlValue::Integer(u64::max_value()))),
+            opcode::ZERO_OP => Ok((new_input, context, AmlValue::Integer(0))),
+            opcode::ONE_OP => Ok((new_input, context, AmlValue::Integer(1))),
+            opcode::ONES_OP => Ok((new_input, context, AmlValue::Integer(u64::max_value()))),
 
-            _ => Err((input, AmlError::UnexpectedByte(op))),
+            _ => Err((input, context, AmlError::UnexpectedByte(op))),
         }
     };
 
@@ -223,40 +256,45 @@ mod test {
 
     #[test]
     fn test_computational_data() {
+        let mut context = AmlContext::new();
         check_ok!(
-            computational_data().parse(&[0x00, 0x34, 0x12]),
+            computational_data().parse(&[0x00, 0x34, 0x12], &mut context),
             AmlValue::Integer(0),
             &[0x34, 0x12]
         );
         check_ok!(
-            computational_data().parse(&[0x01, 0x18, 0xf3]),
+            computational_data().parse(&[0x01, 0x18, 0xf3], &mut context),
             AmlValue::Integer(1),
             &[0x18, 0xf3]
         );
         check_ok!(
-            computational_data().parse(&[0xff, 0x98, 0xc3]),
+            computational_data().parse(&[0xff, 0x98, 0xc3], &mut context),
             AmlValue::Integer(u64::max_value()),
             &[0x98, 0xc3]
         );
         check_ok!(
-            computational_data().parse(&[0x5b, 0x30]),
+            computational_data().parse(&[0x5b, 0x30], &mut context),
             AmlValue::Integer(crate::AML_INTERPRETER_REVISION),
             &[]
         );
         check_ok!(
-            computational_data().parse(&[0x0a, 0xf3, 0x35]),
+            computational_data().parse(&[0x0a, 0xf3, 0x35], &mut context),
             AmlValue::Integer(0xf3),
             &[0x35]
         );
-        check_ok!(computational_data().parse(&[0x0b, 0xf3, 0x35]), AmlValue::Integer(0x35f3), &[]);
         check_ok!(
-            computational_data().parse(&[0x0c, 0xf3, 0x35, 0x12, 0x65, 0xff, 0x00]),
+            computational_data().parse(&[0x0b, 0xf3, 0x35], &mut context),
+            AmlValue::Integer(0x35f3),
+            &[]
+        );
+        check_ok!(
+            computational_data().parse(&[0x0c, 0xf3, 0x35, 0x12, 0x65, 0xff, 0x00], &mut context),
             AmlValue::Integer(0x651235f3),
             &[0xff, 0x00]
         );
         check_ok!(
             computational_data()
-                .parse(&[0x0e, 0xf3, 0x35, 0x12, 0x65, 0xff, 0x00, 0x67, 0xde, 0x28]),
+                .parse(&[0x0e, 0xf3, 0x35, 0x12, 0x65, 0xff, 0x00, 0x67, 0xde, 0x28], &mut context),
             AmlValue::Integer(0xde6700ff651235f3),
             &[0x28]
         );

--- a/aml_parser/src/term_object.rs
+++ b/aml_parser/src/term_object.rs
@@ -1,5 +1,5 @@
 use crate::{
-    name_object::{name_seg, name_string},
+    name_object::{name_seg, name_string, AmlName},
     opcode::{self, ext_opcode, opcode},
     parser::{
         choice,

--- a/aml_parser/src/term_object.rs
+++ b/aml_parser/src/term_object.rs
@@ -1,0 +1,46 @@
+use crate::{
+    name_object::name_string,
+    opcode::{opcode, SCOPE_OP},
+    parser::{choice, comment, comment_scope, take_n, ParseResult, Parser},
+    pkg_length::{pkg_length, PkgLength},
+    AmlNamespace,
+};
+use log::{debug, trace};
+
+/// `TermList`s are usually found within explicit-length objects (so they have a `PkgLength`
+/// elsewhere in the structure), so this takes a number of bytes to parse.
+pub fn term_list<'a>(list_length: PkgLength) -> impl Parser<'a, ()> {
+    /*
+     * TermList := Nothing | <TermObj TermList>
+     */
+    move |input: &'a [u8]| -> ParseResult<'a, ()> {
+        while list_length.still_parsing(input) {
+            let (input, ()) = term_object().parse(input)?;
+        }
+        Ok((input, ()))
+    }
+}
+
+// TODO: maybe return `AmlValue` on success
+pub fn term_object<'a>() -> impl Parser<'a, ()> {
+    /*
+     * TermObj := NamespaceModifierObj | NamedObj | Type1Opcode | Type2Opcode
+     * NamespaceModifierObj := DefAlias | DefName | DefScope
+     */
+    comment_scope("TermObj", choice!(def_scope()))
+}
+
+pub fn def_scope<'a>() -> impl Parser<'a, ()> {
+    /*
+     * DefScope := 0x10 PkgLength NameString TermList
+     */
+    opcode(SCOPE_OP)
+        .then(comment_scope(
+            "DefScope",
+            pkg_length().then(name_string()).feed(move |(pkg_length, name)| {
+                debug!("Scope with name: {}, length: {:?}", name, pkg_length);
+                term_list(pkg_length)
+            }),
+        ))
+        .discard_result()
+}

--- a/aml_parser/src/term_object.rs
+++ b/aml_parser/src/term_object.rs
@@ -84,6 +84,7 @@ where
             def_method(),
             def_device(),
             def_processor(),
+            def_mutex()
         ),
     )
 }
@@ -406,6 +407,27 @@ where
         ))
         .discard_result()
 }
+
+pub fn def_mutex<'a, 'c>() -> impl Parser<'a, 'c, ()>
+where
+    'c: 'a,
+{
+    /*
+     * DefMutex := ExtOpPrefix 0x01 NameString SyncFlags
+     * SyncFlags := ByteData (where bits 0-3: SyncLevel
+     *                              bits 4-7: Reserved)
+     */
+    ext_opcode(opcode::EXT_DEF_MUTEX_OP)
+        .then(comment_scope(
+            "DefMutex",
+            name_string().then(take()).map(|(name, sync_flags)| {
+                trace!("Defined mutex with name {} and sync flags {:b}", name, sync_flags);
+                Ok(())
+            }),
+        ))
+        .discard_result()
+}
+
 pub fn term_arg<'a, 'c>() -> impl Parser<'a, 'c, AmlValue>
 where
     'c: 'a,

--- a/aml_parser/src/term_object.rs
+++ b/aml_parser/src/term_object.rs
@@ -14,10 +14,12 @@ pub fn term_list<'a>(list_length: PkgLength) -> impl Parser<'a, ()> {
     /*
      * TermList := Nothing | <TermObj TermList>
      */
-    move |input: &'a [u8]| -> ParseResult<'a, ()> {
+    move |mut input: &'a [u8]| -> ParseResult<'a, ()> {
         while list_length.still_parsing(input) {
-            let (input, ()) = term_object().parse(input)?;
+            let (new_input, ()) = term_object().parse(input)?;
+            input = new_input;
         }
+
         Ok((input, ()))
     }
 }

--- a/aml_parser/src/term_object.rs
+++ b/aml_parser/src/term_object.rs
@@ -227,24 +227,23 @@ where
      * object (it seems to be defined in ASL). We treat BufferData as if it was encoded like
      * DefBuffer, and this seems to work so far.
      */
-    // TODO: replace these maps with `with_context` and register the fields in the namespace
     // TODO: parse ConnectField and ExtendedAccessField
-    let reserved_field = opcode(opcode::RESERVED_FIELD).then(pkg_length()).map_with_context(
-        |((), pkg_length), context| {
-            trace!("Adding reserved field with length: {}", pkg_length.raw_length);
-            // TODO: put it in the namespace
-            ((), context)
-        },
-    );
 
-    let access_field = opcode(opcode::ACCESS_FIELD).then(take()).then(take()).map(
-        |(((), access_type), access_attrib)| {
+    /*
+     * Reserved fields shouldn't actually be added to the namespace; they seem to show gaps in
+     * the operation region that aren't used for anything.
+     */
+    let reserved_field = opcode(opcode::RESERVED_FIELD).then(pkg_length()).discard_result();
+
+    let access_field = opcode(opcode::ACCESS_FIELD).then(take()).then(take()).map_with_context(
+        |(((), access_type), access_attrib), context| {
             trace!(
                 "Adding access field with access_type: {}, access_attrib: {}",
                 access_type,
                 access_attrib
             );
             // TODO: put it in the namespace
+            ((), context)
         },
     );
 

--- a/aml_parser/src/term_object.rs
+++ b/aml_parser/src/term_object.rs
@@ -4,6 +4,7 @@ use crate::{
     parser::{
         choice,
         comment_scope,
+        comment_scope_verbose,
         take,
         take_to_end_of_pkglength,
         take_u16,
@@ -47,7 +48,7 @@ where
     /*
      * TermObj := NamespaceModifierObj | NamedObj | Type1Opcode | Type2Opcode
      */
-    comment_scope("TermObj", choice!(namespace_modifier(), named_obj()))
+    comment_scope_verbose("TermObj", choice!(namespace_modifier(), named_obj()))
 }
 
 pub fn namespace_modifier<'a, 'c>() -> impl Parser<'a, 'c, ()>
@@ -73,7 +74,13 @@ where
      * XXX: DefMethod and DefMutex (at least) are not included in any rule in the AML grammar,
      * but are defined in the NamedObj section so we assume they're part of NamedObj
      */
-    comment_scope("NamedObj", choice!(def_op_region(), def_field(), def_method(), def_device()))
+    comment_scope_verbose(
+        "NamedObj",
+        choice!(
+            def_op_region(),
+            def_field(),
+            def_method(),
+            def_device(),
 }
 
 pub fn def_name<'a, 'c>() -> impl Parser<'a, 'c, ()>
@@ -311,7 +318,7 @@ where
      * TermArg := Type2Opcode | DataObject | ArgObj | LocalObj
      */
     // TODO: this doesn't yet parse Term2Opcode, ArgObj, or LocalObj
-    comment_scope("TermArg", choice!(data_object()))
+    comment_scope_verbose("TermArg", choice!(data_object()))
 }
 
 pub fn data_ref_object<'a, 'c>() -> impl Parser<'a, 'c, AmlValue>
@@ -321,7 +328,7 @@ where
     /*
      * DataRefObject := DataObject | ObjectReference | DDBHandle
      */
-    comment_scope("DataRefObject", choice!(data_object()))
+    comment_scope_verbose("DataRefObject", choice!(data_object()))
 }
 
 pub fn data_object<'a, 'c>() -> impl Parser<'a, 'c, AmlValue>
@@ -378,7 +385,7 @@ where
         }
     };
 
-    comment_scope(
+    comment_scope_verbose(
         "ComputationalData",
         choice!(
             ext_opcode(opcode::EXT_REVISION_OP)

--- a/aml_parser/src/test_utils.rs
+++ b/aml_parser/src/test_utils.rs
@@ -2,6 +2,9 @@ pub(crate) macro check_err($parse: expr, $error: pat, $remains: expr) {
     match $parse {
         Ok(result) => panic!("Expected Err, got {:#?}", result),
         Err((remains, $error)) if *remains == *$remains => (),
+        Err((remains, $error)) => {
+            panic!("Correct error, incorrect stream returned: {:x?}", remains)
+        }
         Err((_, err)) => panic!("Got wrong error: {:?}", err),
     }
 }
@@ -9,6 +12,9 @@ pub(crate) macro check_err($parse: expr, $error: pat, $remains: expr) {
 pub(crate) macro check_ok($parse: expr, $expected: expr, $remains: expr) {
     match $parse {
         Ok((remains, result)) if remains == *$remains && result == $expected => (),
+        Ok((remains, result)) if result == $expected => {
+            panic!("Correct result, incorrect slice returned: {:x?}", remains)
+        }
         Ok(result) => panic!("Successfully parsed Ok, but it was wrong: {:#?}", result),
         Err((_, err)) => panic!("Expected Ok, got {:#?}", err),
     }

--- a/aml_parser/src/test_utils.rs
+++ b/aml_parser/src/test_utils.rs
@@ -1,21 +1,21 @@
 pub(crate) macro check_err($parse: expr, $error: pat, $remains: expr) {
     match $parse {
         Ok(result) => panic!("Expected Err, got {:#?}", result),
-        Err((remains, $error)) if *remains == *$remains => (),
-        Err((remains, $error)) => {
+        Err((remains, _, $error)) if *remains == *$remains => (),
+        Err((remains, _, $error)) => {
             panic!("Correct error, incorrect stream returned: {:x?}", remains)
         }
-        Err((_, err)) => panic!("Got wrong error: {:?}", err),
+        Err((_, _, err)) => panic!("Got wrong error: {:?}", err),
     }
 }
 
 pub(crate) macro check_ok($parse: expr, $expected: expr, $remains: expr) {
     match $parse {
-        Ok((remains, ref result)) if remains == *$remains && result == &$expected => (),
-        Ok((remains, ref result)) if result == &$expected => {
+        Ok((remains, _, ref result)) if remains == *$remains && result == &$expected => (),
+        Ok((remains, _, ref result)) if result == &$expected => {
             panic!("Correct result, incorrect slice returned: {:x?}", remains)
         }
         Ok(result) => panic!("Successfully parsed Ok, but it was wrong: {:#?}", result),
-        Err((_, err)) => panic!("Expected Ok, got {:#?}", err),
+        Err((_, _, err)) => panic!("Expected Ok, got {:#?}", err),
     }
 }

--- a/aml_parser/src/test_utils.rs
+++ b/aml_parser/src/test_utils.rs
@@ -1,0 +1,15 @@
+pub(crate) macro check_err($parse: expr, $error: pat, $remains: expr) {
+    match $parse {
+        Ok(result) => panic!("Expected Err, got {:#?}", result),
+        Err((remains, $error)) if *remains == *$remains => (),
+        Err((_, err)) => panic!("Got wrong error: {:?}", err),
+    }
+}
+
+pub(crate) macro check_ok($parse: expr, $expected: expr, $remains: expr) {
+    match $parse {
+        Ok((remains, result)) if remains == *$remains && result == $expected => (),
+        Ok(result) => panic!("Successfully parsed Ok, but it was wrong: {:#?}", result),
+        Err((_, err)) => panic!("Expected Ok, got {:#?}", err),
+    }
+}

--- a/aml_parser/src/test_utils.rs
+++ b/aml_parser/src/test_utils.rs
@@ -11,8 +11,8 @@ pub(crate) macro check_err($parse: expr, $error: pat, $remains: expr) {
 
 pub(crate) macro check_ok($parse: expr, $expected: expr, $remains: expr) {
     match $parse {
-        Ok((remains, result)) if remains == *$remains && result == $expected => (),
-        Ok((remains, result)) if result == $expected => {
+        Ok((remains, ref result)) if remains == *$remains && result == &$expected => (),
+        Ok((remains, ref result)) if result == &$expected => {
             panic!("Correct result, incorrect slice returned: {:x?}", remains)
         }
         Ok(result) => panic!("Successfully parsed Ok, but it was wrong: {:#?}", result),

--- a/aml_parser/src/value.rs
+++ b/aml_parser/src/value.rs
@@ -1,5 +1,5 @@
-use crate::AmlError;
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use crate::{name_object::AmlName, AmlError};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use bit_field::BitField;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -95,11 +95,14 @@ impl MethodFlags {
 pub enum AmlValue {
     Integer(u64),
     String(String),
-    Scope(BTreeMap<String, AmlValue>),
+    Name(Box<AmlValue>),
     OpRegion { region: RegionSpace, offset: u64, length: u64 },
-    Field { flags: FieldFlags, offset: u64, length: u64 },
+    Field { region: AmlName, flags: FieldFlags, offset: u64, length: u64 },
+    Device,
     Method { flags: MethodFlags, code: Vec<u8> },
     Buffer { bytes: Vec<u8>, size: u64 },
+    Processor { id: u8, pblk_address: u32, pblk_len: u8 },
+    Mutex { sync_level: u8 },
     Package(Vec<AmlValue>),
 }
 

--- a/aml_parser/src/value.rs
+++ b/aml_parser/src/value.rs
@@ -1,4 +1,5 @@
 use crate::AmlError;
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
 use bit_field::BitField;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -93,5 +94,6 @@ impl MethodFlags {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum AmlValue {
     Integer(u64),
+    String(String),
     Field { flags: FieldFlags, offset: u64, length: u64 },
 }

--- a/aml_parser/src/value.rs
+++ b/aml_parser/src/value.rs
@@ -1,4 +1,75 @@
+use crate::AmlError;
+use bit_field::BitField;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RegionSpace {
+    SystemMemory,
+    SystemIo,
+    PciConfig,
+    EmbeddedControl,
+    SMBus,
+    SystemCmos,
+    PciBarTarget,
+    IPMI,
+    GeneralPurposeIo,
+    GenericSerialBus,
+    OemDefined(u8),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FieldAccessType {
+    Any,
+    Byte,
+    Word,
+    DWord,
+    QWord,
+    Buffer,
+    Reserved,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FieldUpdateRule {
+    Preserve,
+    WriteAsOnes,
+    WriteAsZeros,
+}
+
+// TODO: custom debug impl
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct FieldFlags(u8);
+
+impl FieldFlags {
+    pub fn new(value: u8) -> FieldFlags {
+        FieldFlags(value)
+    }
+
+    pub fn access_type(&self) -> Result<FieldAccessType, AmlError> {
+        match self.0.get_bits(0..4) {
+            0 => Ok(FieldAccessType::Any),
+            1 => Ok(FieldAccessType::Byte),
+            2 => Ok(FieldAccessType::Word),
+            3 => Ok(FieldAccessType::DWord),
+            4 => Ok(FieldAccessType::QWord),
+            5 => Ok(FieldAccessType::Buffer),
+            _ => Err(AmlError::InvalidFieldFlags),
+        }
+    }
+
+    pub fn lock_rule(&self) -> bool {
+        self.0.get_bit(4)
+    }
+
+    pub fn field_update_rule(&self) -> Result<FieldUpdateRule, AmlError> {
+        match self.0.get_bits(5..7) {
+            0 => Ok(FieldUpdateRule::Preserve),
+            1 => Ok(FieldUpdateRule::WriteAsOnes),
+            2 => Ok(FieldUpdateRule::WriteAsZeros),
+            _ => Err(AmlError::InvalidFieldFlags),
+        }
+    }
+}
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum AmlValue {
     Integer(u64),
+    Field { flags: FieldFlags, offset: u64, length: u64 },
 }

--- a/aml_parser/src/value.rs
+++ b/aml_parser/src/value.rs
@@ -1,1 +1,4 @@
-pub enum AmlValue {}
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum AmlValue {
+    Integer(u64),
+}

--- a/aml_parser/src/value.rs
+++ b/aml_parser/src/value.rs
@@ -96,4 +96,30 @@ pub enum AmlValue {
     Integer(u64),
     String(String),
     Field { flags: FieldFlags, offset: u64, length: u64 },
+impl AmlValue {
+    pub fn as_integer(&self) -> Result<u64, AmlError> {
+        match self {
+            AmlValue::Integer(value) => Ok(*value),
+
+            AmlValue::Buffer { size, ref bytes } => {
+                /*
+                 * "The first 8 bytes of the buffer are converted to an integer, taking the first
+                 * byte as the least significant byte of the integer. A zero-length buffer is
+                 * illegal." - §19.6.140
+                 *
+                 * XXX: We return `0` for zero-length buffers because they literally occur in
+                 * the reference implementation.
+                 */
+                let bytes = if bytes.len() > 8 { &bytes[0..8] } else { bytes };
+
+                Ok(bytes.iter().rev().fold(0: u64, |mut i, &popped| {
+                    i <<= 8;
+                    i += popped as u64;
+                    i
+                }))
+            }
+
+            _ => Err(AmlError::IncompatibleValueConversion),
+        }
+    }
 }

--- a/aml_parser/src/value.rs
+++ b/aml_parser/src/value.rs
@@ -96,6 +96,9 @@ pub enum AmlValue {
     Integer(u64),
     String(String),
     Field { flags: FieldFlags, offset: u64, length: u64 },
+    Package(Vec<AmlValue>),
+}
+
 impl AmlValue {
     pub fn as_integer(&self) -> Result<u64, AmlError> {
         match self {

--- a/aml_parser/src/value.rs
+++ b/aml_parser/src/value.rs
@@ -68,6 +68,28 @@ impl FieldFlags {
         }
     }
 }
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct MethodFlags(u8);
+
+impl MethodFlags {
+    pub fn new(value: u8) -> MethodFlags {
+        MethodFlags(value)
+    }
+
+    pub fn arg_count(&self) -> u8 {
+        self.0.get_bits(0..3)
+    }
+
+    pub fn serialize(&self) -> bool {
+        self.0.get_bit(3)
+    }
+
+    pub fn sync_level(&self) -> u8 {
+        self.0.get_bits(4..8)
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum AmlValue {
     Integer(u64),

--- a/aml_parser/src/value.rs
+++ b/aml_parser/src/value.rs
@@ -95,7 +95,11 @@ impl MethodFlags {
 pub enum AmlValue {
     Integer(u64),
     String(String),
+    Scope(BTreeMap<String, AmlValue>),
+    OpRegion { region: RegionSpace, offset: u64, length: u64 },
     Field { flags: FieldFlags, offset: u64, length: u64 },
+    Method { flags: MethodFlags, code: Vec<u8> },
+    Buffer { bytes: Vec<u8>, size: u64 },
     Package(Vec<AmlValue>),
 }
 

--- a/aml_parser/src/value.rs
+++ b/aml_parser/src/value.rs
@@ -1,0 +1,1 @@
+pub enum AmlValue {}


### PR DESCRIPTION
TODO:
- [x] Add attribution note to Bodil's combinators blog post, and general parser documentation
- [x] Investigate representing `Map` as a concrete type and implementing it on `Parser`
- [x] Parse `PkgLength`
- [x] Parse `NameString`
- [x] Parse `TermList`
- [x] Parse `TermObj`
- [x] Parse `DefScope`
- [x] Parse `DefOpRegion`
- [x] Parse `DefField`
- [x] Parse `DefMethod`
- [x] Parse `DefDevice`
- [x] Parse `DefName`
- [x] Parse `DefBuffer`
- [x] Create abstraction and good documentation around hack to avoid recursion limit problem
- [x] Parse `DefPackage`
- [x] Parse `DefProcessor`
- [x] Parse `DefMutex`
- [x] Redo how we represent name objects
- [x] Keep track of scope
- [x] Register stuff in the namespace as we parse it
- [x] Add features to control how much parser debug output is produced

There's also something funky going on with error reporting. Not sure if it's the actual error generation or propagation up the combinators.