### PR TITLE
A few assorted changes

### DIFF
--- a/acpi/Cargo.toml
+++ b/acpi/Cargo.toml
@@ -12,4 +12,3 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 bit_field = "0.10"
-typenum = "1"

--- a/acpi/Cargo.toml
+++ b/acpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acpi"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Isaac Woods"]
 repository = "https://github.com/rust-osdev/acpi"
 description = "Library for parsing ACPI tables"

--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -92,7 +92,7 @@ where
 
     let dsdt_address = unsafe {
         fadt.x_dsdt_address
-            .access(fadt.header.revision())
+            .access(fadt.header.revision)
             .filter(|&p| p != 0)
             .or(Some(fadt.dsdt_address as u64))
             .filter(|p| *p != 0)
@@ -101,7 +101,7 @@ where
 
     acpi.dsdt = dsdt_address.map(|address| {
         let dsdt_header = crate::sdt::peek_at_sdt_header(handler, address);
-        AmlTable::new(address, dsdt_header.length())
+        AmlTable::new(address, dsdt_header.length)
     });
 
     Ok(())

--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -1,6 +1,12 @@
-use crate::{sdt::SdtHeader, Acpi, AcpiError, AcpiHandler, AmlTable, GenericAddress, PhysicalMapping};
-
-type ExtendedField<T> = crate::sdt::ExtendedField<T, typenum::U2>;
+use crate::{
+    sdt::{ExtendedField, SdtHeader, ACPI_VERSION_2_0},
+    Acpi,
+    AcpiError,
+    AcpiHandler,
+    AmlTable,
+    GenericAddress,
+    PhysicalMapping,
+};
 
 /// Represents the Fixed ACPI Description Table (FADT). This table contains various fixed hardware
 /// details, such as the addresses of the hardware register blocks. It also contains a pointer to
@@ -58,19 +64,19 @@ pub struct Fadt {
     reset_value: u8,
     arm_boot_arch: u16,
     fadt_minor_version: u8,
-    x_firmware_ctrl: ExtendedField<u64>,
-    x_dsdt_address: ExtendedField<u64>,
-    x_pm1a_event_block: ExtendedField<GenericAddress>,
-    x_pm1b_event_block: ExtendedField<GenericAddress>,
-    x_pm1a_control_block: ExtendedField<GenericAddress>,
-    x_pm1b_control_block: ExtendedField<GenericAddress>,
-    x_pm2_control_block: ExtendedField<GenericAddress>,
-    x_pm_timer_block: ExtendedField<GenericAddress>,
-    x_gpe0_block: ExtendedField<GenericAddress>,
-    x_gpe1_block: ExtendedField<GenericAddress>,
-    sleep_control_reg: ExtendedField<GenericAddress>,
-    sleep_status_reg: ExtendedField<GenericAddress>,
-    hypervisor_vendor_id: ExtendedField<u64>,
+    x_firmware_ctrl: ExtendedField<u64, ACPI_VERSION_2_0>,
+    x_dsdt_address: ExtendedField<u64, ACPI_VERSION_2_0>,
+    x_pm1a_event_block: ExtendedField<GenericAddress, ACPI_VERSION_2_0>,
+    x_pm1b_event_block: ExtendedField<GenericAddress, ACPI_VERSION_2_0>,
+    x_pm1a_control_block: ExtendedField<GenericAddress, ACPI_VERSION_2_0>,
+    x_pm1b_control_block: ExtendedField<GenericAddress, ACPI_VERSION_2_0>,
+    x_pm2_control_block: ExtendedField<GenericAddress, ACPI_VERSION_2_0>,
+    x_pm_timer_block: ExtendedField<GenericAddress, ACPI_VERSION_2_0>,
+    x_gpe0_block: ExtendedField<GenericAddress, ACPI_VERSION_2_0>,
+    x_gpe1_block: ExtendedField<GenericAddress, ACPI_VERSION_2_0>,
+    sleep_control_reg: ExtendedField<GenericAddress, ACPI_VERSION_2_0>,
+    sleep_status_reg: ExtendedField<GenericAddress, ACPI_VERSION_2_0>,
+    hypervisor_vendor_id: ExtendedField<u64, ACPI_VERSION_2_0>,
 }
 
 pub(crate) fn parse_fadt<H>(
@@ -86,8 +92,8 @@ where
 
     let dsdt_address = unsafe {
         fadt.x_dsdt_address
-            .get(fadt.header.revision())
-            .filter(|p| *p != 0)
+            .access(fadt.header.revision())
+            .filter(|&p| p != 0)
             .or(Some(fadt.dsdt_address as u64))
             .filter(|p| *p != 0)
             .map(|p| p as usize)

--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -88,7 +88,7 @@ where
     H: AcpiHandler,
 {
     let fadt = &*mapping;
-    fadt.header.validate(b"FACP")?;
+    fadt.header.validate(crate::sdt::Signature::FADT)?;
 
     let dsdt_address = unsafe {
         fadt.x_dsdt_address

--- a/acpi/src/hpet.rs
+++ b/acpi/src/hpet.rs
@@ -34,7 +34,7 @@ pub(crate) struct HpetTable {
 }
 
 pub(crate) fn parse_hpet(acpi: &mut Acpi, mapping: &PhysicalMapping<HpetTable>) -> Result<(), AcpiError> {
-    (*mapping).header.validate(b"HPET")?;
+    (*mapping).header.validate(crate::sdt::Signature::HPET)?;
     let hpet = &*mapping;
 
     // Make sure the HPET's in system memory

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -48,22 +48,24 @@ pub use crate::{
     rsdp_search::search_for_rsdp_bios,
 };
 
-use crate::{rsdp::Rsdp, sdt::SdtHeader};
+use crate::{
+    rsdp::Rsdp,
+    sdt::{SdtHeader, Signature},
+};
 use alloc::vec::Vec;
 use core::mem;
 
 #[derive(Debug)]
-// TODO: manually implement Debug to print signatures correctly etc.
 pub enum AcpiError {
     RsdpIncorrectSignature,
     RsdpInvalidOemId,
     RsdpInvalidChecksum,
     NoValidRsdp,
 
-    SdtInvalidSignature([u8; 4]),
-    SdtInvalidOemId([u8; 4]),
-    SdtInvalidTableId([u8; 4]),
-    SdtInvalidChecksum([u8; 4]),
+    SdtInvalidSignature(Signature),
+    SdtInvalidOemId(Signature),
+    SdtInvalidTableId(Signature),
+    SdtInvalidChecksum(Signature),
 
     InvalidMadt(MadtError),
 }
@@ -216,7 +218,7 @@ where
         /*
          * ACPI Version 1.0. It's a RSDT!
          */
-        (*mapping).validate(b"RSDT")?;
+        (*mapping).validate(sdt::Signature::RSDT)?;
 
         let num_tables = ((*mapping).length as usize - mem::size_of::<SdtHeader>()) / mem::size_of::<u32>();
         let tables_base = ((mapping.virtual_start.as_ptr() as usize) + mem::size_of::<SdtHeader>()) as *const u32;
@@ -228,7 +230,7 @@ where
         /*
          * ACPI Version 2.0+. It's a XSDT!
          */
-        (*mapping).validate(b"XSDT")?;
+        (*mapping).validate(sdt::Signature::XSDT)?;
 
         let num_tables = ((*mapping).length as usize - mem::size_of::<SdtHeader>()) / mem::size_of::<u64>();
         let tables_base = ((mapping.virtual_start.as_ptr() as usize) + mem::size_of::<SdtHeader>()) as *const u64;

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -22,7 +22,7 @@
 //! gathered from the static tables, and can be queried to set up hardware etc.
 
 #![no_std]
-#![feature(nll, exclusive_range_pattern)]
+#![feature(nll, exclusive_range_pattern, const_generics)]
 
 extern crate alloc;
 #[cfg_attr(test, macro_use)]

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -210,7 +210,7 @@ where
     };
 
     let header = sdt::peek_at_sdt_header(handler, physical_address);
-    let mapping = handler.map_physical_region::<SdtHeader>(physical_address, header.length() as usize);
+    let mapping = handler.map_physical_region::<SdtHeader>(physical_address, header.length as usize);
 
     if revision == 0 {
         /*
@@ -218,7 +218,7 @@ where
          */
         (*mapping).validate(b"RSDT")?;
 
-        let num_tables = ((*mapping).length() as usize - mem::size_of::<SdtHeader>()) / mem::size_of::<u32>();
+        let num_tables = ((*mapping).length as usize - mem::size_of::<SdtHeader>()) / mem::size_of::<u32>();
         let tables_base = ((mapping.virtual_start.as_ptr() as usize) + mem::size_of::<SdtHeader>()) as *const u32;
 
         for i in 0..num_tables {
@@ -230,7 +230,7 @@ where
          */
         (*mapping).validate(b"XSDT")?;
 
-        let num_tables = ((*mapping).length() as usize - mem::size_of::<SdtHeader>()) / mem::size_of::<u64>();
+        let num_tables = ((*mapping).length as usize - mem::size_of::<SdtHeader>()) / mem::size_of::<u64>();
         let tables_base = ((mapping.virtual_start.as_ptr() as usize) + mem::size_of::<SdtHeader>()) as *const u64;
 
         for i in 0..num_tables {

--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -337,7 +337,7 @@ pub(crate) fn parse_madt<H>(
 where
     H: AcpiHandler,
 {
-    (*mapping).header.validate(b"APIC")?;
+    (*mapping).header.validate(crate::sdt::Signature::MADT)?;
 
     /*
      * If the MADT doesn't contain another supported interrupt model (either APIC, SAPIC, X2APIC

--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -41,7 +41,7 @@ impl Madt {
     fn entries(&self) -> MadtEntryIter {
         MadtEntryIter {
             pointer: unsafe { (self as *const Madt as *const u8).offset(mem::size_of::<Madt>() as isize) },
-            remaining_length: self.header.length() - mem::size_of::<Madt>() as u32,
+            remaining_length: self.header.length - mem::size_of::<Madt>() as u32,
             _phantom: PhantomData,
         }
     }

--- a/acpi/src/mcfg.rs
+++ b/acpi/src/mcfg.rs
@@ -42,7 +42,7 @@ pub(crate) struct Mcfg {
 
 impl Mcfg {
     fn entries(&self) -> &[McfgEntry] {
-        let length = self.header.length() as usize - mem::size_of::<Mcfg>();
+        let length = self.header.length as usize - mem::size_of::<Mcfg>();
 
         // intentionally round down in case length isn't an exact multiple of McfgEntry size
         let num_entries = length / mem::size_of::<McfgEntry>();

--- a/acpi/src/mcfg.rs
+++ b/acpi/src/mcfg.rs
@@ -66,7 +66,7 @@ struct McfgEntry {
 }
 
 pub(crate) fn parse_mcfg(acpi: &mut Acpi, mapping: &PhysicalMapping<Mcfg>) -> Result<(), AcpiError> {
-    (*mapping).header.validate(b"MCFG")?;
+    (*mapping).header.validate(crate::sdt::Signature::MCFG)?;
 
     acpi.pci_config_regions =
         Some(PciConfigRegions { regions: mapping.entries().iter().map(|&entry| entry).collect() });

--- a/acpi/src/sdt.rs
+++ b/acpi/src/sdt.rs
@@ -61,14 +61,14 @@ impl<T: Copy, const MIN_VERSION: u8> ExtendedField<T, MIN_VERSION> {
 #[repr(C, packed)]
 pub struct SdtHeader {
     signature: [u8; 4],
-    length: u32,
-    revision: u8,
-    checksum: u8,
-    oem_id: [u8; 6],
-    oem_table_id: [u8; 8],
-    oem_revision: u32,
-    creator_id: u32,
-    creator_revision: u32,
+    pub length: u32,
+    pub revision: u8,
+    pub checksum: u8,
+    pub oem_id: [u8; 6],
+    pub oem_table_id: [u8; 8],
+    pub oem_revision: u32,
+    pub creator_id: u32,
+    pub creator_revision: u32,
 }
 
 impl SdtHeader {
@@ -107,23 +107,6 @@ impl SdtHeader {
         Ok(())
     }
 
-    pub fn raw_signature(&self) -> [u8; 4] {
-        self.signature
-    }
-
-    pub fn signature<'a>(&'a self) -> &'a str {
-        // Safe to unwrap because we check signature is valid UTF8 in `validate`
-        str::from_utf8(&self.signature).unwrap()
-    }
-
-    pub fn length(&self) -> u32 {
-        self.length
-    }
-
-    pub fn revision(&self) -> u8 {
-        self.revision
-    }
-
     pub fn oem_id<'a>(&'a self) -> &'a str {
         // Safe to unwrap because checked in `validate`
         str::from_utf8(&self.oem_id).unwrap()
@@ -155,14 +138,14 @@ where
     H: AcpiHandler,
 {
     let header = peek_at_sdt_header(handler, physical_address);
-    trace!("Found ACPI table with signature {:?} and length {:?}", header.signature(), header.length());
+    trace!("Found ACPI table with signature {:?} and length {:?}", header.signature, header.length);
 
     /*
      * For a recognised signature, a new physical mapping should be created with the correct type
      * and length, and then the dispatched to the correct function to actually parse the table.
      */
-    match header.signature() {
         "FACP" => {
+    match header.signature {
             let fadt_mapping = handler.map_physical_region::<Fadt>(physical_address, mem::size_of::<Fadt>());
             crate::fadt::parse_fadt(acpi, handler, &fadt_mapping)?;
             handler.unmap_physical_region(fadt_mapping);

--- a/aml/Cargo.toml
+++ b/aml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aml"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Isaac Woods"]
 repository = "https://github.com/rust-osdev/acpi"
 description = "Library for parsing AML"

--- a/aml/src/parser.rs
+++ b/aml/src/parser.rs
@@ -168,7 +168,6 @@ where
     }
 }
 
-// TODO: can we use const generics (e.g. [R; N]) to avoid allocating?
 pub fn n_of<'a, 'c, P, R>(parser: P, n: usize) -> impl Parser<'a, 'c, Vec<R>>
 where
     'c: 'a,


### PR DESCRIPTION
This upstreams a few assorted changes that I seem to have accumulated. Specifically:
* It removes the dependency on `typenum` (replacing them with const generics) to hopefully make `acpi` slightly smaller
* It makes accessing extended fields sound (I think it was unsound before, and just never seemed to miscompile), by treating them as uninitialised memory (instead of potentially treating them as initialised `()` types) until the version is checked
* It introduces a `Signature` type to represent SDT signatures
* It moves some AML opcode parsers around to be in the right place

Closes #44 