### PR TITLE
Parse prefix chars in NameStrings and make HPET fields public

### DIFF
--- a/acpi/Cargo.toml
+++ b/acpi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acpi"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Isaac Woods"]
 repository = "https://github.com/rust-osdev/acpi"
 description = "Library for parsing ACPI tables"

--- a/acpi/src/hpet.rs
+++ b/acpi/src/hpet.rs
@@ -14,13 +14,12 @@ pub enum PageProtection {
 /// Information about the High Precision Event Timer
 #[derive(Debug)]
 pub struct HpetInfo {
-    event_timer_block_id: u32,
-    base_address: usize,
-    hpet_number: u8,
-    /// The minimum number of clock ticks that can be set without losing interrupts (for timers in
-    /// Periodic Mode)
-    clock_tick_unit: u16,
-    page_protection: PageProtection,
+    pub event_timer_block_id: u32,
+    pub base_address: usize,
+    pub hpet_number: u8,
+    /// The minimum number of clock ticks that can be set without losing interrupts (for timers in Periodic Mode)
+    pub clock_tick_unit: u16,
+    pub page_protection: PageProtection,
 }
 
 #[repr(C, packed)]

--- a/aml/Cargo.toml
+++ b/aml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aml"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Isaac Woods"]
 repository = "https://github.com/rust-osdev/acpi"
 description = "Library for parsing AML"

--- a/aml/src/parser.rs
+++ b/aml/src/parser.rs
@@ -191,6 +191,27 @@ where
     }
 }
 
+pub fn take_while<'a, 'c, P, R>(parser: P) -> impl Parser<'a, 'c, usize>
+where
+    'c: 'a,
+    P: Parser<'a, 'c, R>,
+{
+    move |mut input: &'a [u8], mut context: &'c mut AmlContext| {
+        let mut num_passed = 0;
+        loop {
+            match parser.parse(input, context) {
+                Ok((new_input, new_context, _)) => {
+                    input = new_input;
+                    context = new_context;
+                    num_passed += 1;
+                }
+                Err((_, context, AmlError::WrongParser)) => return Ok((input, context, num_passed)),
+                Err((_, context, err)) => return Err((input, context, err)),
+            }
+        }
+    }
+}
+
 pub fn consume<'a, 'c, F>(condition: F) -> impl Parser<'a, 'c, u8>
 where
     'c: 'a,


### PR DESCRIPTION
Fixes #66 

This should fix an error encountered if a `NameString` actually uses prefix chars (`^`). Also makes the fields of the `HpetInfo` struct public, which was requested on Gitter.

bors r+