### PR TITLE
Initialize objects and support all _STAs and _INIs on QEMU tables

### DIFF
--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -22,7 +22,7 @@
 //! gathered from the static tables, and can be queried to set up hardware etc.
 
 #![no_std]
-#![feature(const_generics)]
+#![feature(const_generics, unsafe_block_in_unsafe_fn)]
 
 extern crate alloc;
 #[cfg_attr(test, macro_use)]

--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -328,7 +328,7 @@ impl AmlContext {
             Target::Name(ref path) => {
                 let (_, handle) = self.namespace.search(path, &self.current_scope)?;
                 let desired_type = self.namespace.get(handle).unwrap().type_of();
-                let converted_object = value.as_type(desired_type)?;
+                let converted_object = value.as_type(desired_type, self)?;
 
                 *self.namespace.get_mut(handle)? = converted_object;
                 Ok(self.namespace.get(handle)?.clone())

--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -475,4 +475,7 @@ pub enum AmlError {
     InvalidStatusObject,
     InvalidShiftLeft,
     InvalidShiftRight,
+    FieldRegionIsNotOpRegion,
+    FieldInvalidAddress,
+    FieldInvalidAccessSize,
 }

--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -405,7 +405,9 @@ pub trait Handler {
     fn write_io_u16(&self, port: u16, value: u16);
     fn write_io_u32(&self, port: u16, value: u32);
 
-    // TODO: PCI config space accessing functions
+    fn read_pci_u8(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u8;
+    fn read_pci_u16(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u16;
+    fn read_pci_u32(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u32;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -373,6 +373,30 @@ impl AmlContext {
     }
 }
 
+pub trait Handler {
+    fn read_u8(&self, address: usize) -> u8;
+    fn read_u16(&self, address: usize) -> u16;
+    fn read_u32(&self, address: usize) -> u32;
+    fn read_u64(&self, address: usize) -> u64;
+
+    fn write_u8(&mut self, address: usize, value: u8);
+    fn write_u16(&mut self, address: usize, value: u16);
+    fn write_u32(&mut self, address: usize, value: u32);
+    fn write_u64(&mut self, address: usize, value: u64);
+
+    fn read_io_u8(&self, port: u16) -> u8;
+    fn read_io_u16(&self, port: u16) -> u16;
+    fn read_io_u32(&self, port: u16) -> u32;
+    fn read_io_u64(&self, port: u16) -> u64;
+
+    fn write_io_u8(&self, port: u16, value: u8);
+    fn write_io_u16(&self, port: u16, value: u16);
+    fn write_io_u32(&self, port: u16, value: u32);
+    fn write_io_u64(&self, port: u16, value: u64);
+
+    // TODO: PCI config space accessing functions
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AmlError {
     /*

--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -330,4 +330,9 @@ pub enum AmlError {
      */
     ReservedResourceType,
     ResourceDescriptorTooShort,
+
+    /*
+     * Errors produced working with AML values.
+     */
+    InvalidStatusObject,
 }

--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -391,4 +391,6 @@ pub enum AmlError {
      * Errors produced working with AML values.
      */
     InvalidStatusObject,
+    InvalidShiftLeft,
+    InvalidShiftRight,
 }

--- a/aml/src/name_object.rs
+++ b/aml/src/name_object.rs
@@ -20,6 +20,21 @@ pub enum Target {
     Local(LocalNum),
 }
 
+pub fn target<'a, 'c>() -> impl Parser<'a, 'c, Target>
+where
+    'c: 'a,
+{
+    /*
+     * Target := SuperName | NullName
+     * NullName := 0x00
+     */
+    comment_scope(
+        DebugVerbosity::AllScopes,
+        "Target",
+        choice!(null_name().map(|_| Ok(Target::Null)), super_name()),
+    )
+}
+
 pub fn super_name<'a, 'c>() -> impl Parser<'a, 'c, Target>
 where
     'c: 'a,

--- a/aml/src/name_object.rs
+++ b/aml/src/name_object.rs
@@ -45,9 +45,9 @@ where
         DebugVerbosity::AllScopes,
         "SimpleName",
         choice!(
-            name_string().map(move |name| Ok(Target::Name(name))),
             arg_obj().map(|arg_num| Ok(Target::Arg(arg_num))),
-            local_obj().map(|local_num| Ok(Target::Local(local_num)))
+            local_obj().map(|local_num| Ok(Target::Local(local_num))),
+            name_string().map(move |name| Ok(Target::Name(name)))
         ),
     )
 }

--- a/aml/src/name_object.rs
+++ b/aml/src/name_object.rs
@@ -244,11 +244,11 @@ fn is_name_char(byte: u8) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{parser::Parser, test_utils::*, AmlContext, AmlError, DebugVerbosity};
+    use crate::{parser::Parser, test_utils::*, AmlError};
 
     #[test]
     fn test_name_seg() {
-        let mut context = AmlContext::new(false, DebugVerbosity::None);
+        let mut context = crate::test_utils::make_test_context();
 
         check_ok!(
             name_seg().parse(&[b'A', b'F', b'3', b'Z'], &mut context),
@@ -270,7 +270,7 @@ mod tests {
 
     #[test]
     fn test_name_path() {
-        let mut context = AmlContext::new(false, DebugVerbosity::None);
+        let mut context = crate::test_utils::make_test_context();
 
         check_err!(name_path().parse(&[], &mut context), AmlError::UnexpectedEndOfStream, &[]);
         check_ok!(name_path().parse(&[0x00], &mut context), alloc::vec![], &[]);
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn test_prefix_path() {
-        let mut context = AmlContext::new(false, DebugVerbosity::None);
+        let mut context = crate::test_utils::make_test_context();
 
         check_ok!(
             name_string().parse(&[b'^', b'A', b'B', b'C', b'D'], &mut context),

--- a/aml/src/name_object.rs
+++ b/aml/src/name_object.rs
@@ -13,6 +13,7 @@ use core::{fmt, str};
 /// Produced by the `Target`, `SimpleName`, and `SuperName` parsers
 #[derive(Clone, Debug)]
 pub enum Target {
+    Null,
     Name(AmlName),
     Debug,
     Arg(ArgNum),

--- a/aml/src/namespace.rs
+++ b/aml/src/namespace.rs
@@ -161,15 +161,18 @@ impl Namespace {
         Ok(self.object_map.get_mut(&handle).unwrap())
     }
 
-    pub fn get_by_path(&self, path: &AmlName) -> Result<&AmlValue, AmlError> {
+    pub fn get_handle(&self, path: &AmlName) -> Result<AmlHandle, AmlError> {
         let (level, last_seg) = self.get_level_for_path(path)?;
-        let &handle = level.values.get(&last_seg).ok_or(AmlError::ValueDoesNotExist(path.clone()))?;
+        Ok(*level.values.get(&last_seg).ok_or(AmlError::ValueDoesNotExist(path.clone()))?)
+    }
+
+    pub fn get_by_path(&self, path: &AmlName) -> Result<&AmlValue, AmlError> {
+        let handle = self.get_handle(path)?;
         Ok(self.get(handle).unwrap())
     }
 
     pub fn get_by_path_mut(&mut self, path: &AmlName) -> Result<&mut AmlValue, AmlError> {
-        let (level, last_seg) = self.get_level_for_path(path)?;
-        let &handle = level.values.get(&last_seg).ok_or(AmlError::ValueDoesNotExist(path.clone()))?;
+        let handle = self.get_handle(path)?;
         Ok(self.get_mut(handle).unwrap())
     }
 

--- a/aml/src/namespace.rs
+++ b/aml/src/namespace.rs
@@ -35,6 +35,7 @@ pub enum LevelType {
     MethodLocals,
 }
 
+#[derive(Clone, Debug)]
 pub struct NamespaceLevel {
     pub typ: LevelType,
     pub children: BTreeMap<NameSeg, NamespaceLevel>,
@@ -47,6 +48,7 @@ impl NamespaceLevel {
     }
 }
 
+#[derive(Clone)]
 pub struct Namespace {
     /// This is a running count of ids, which are never reused. This is incremented every time we
     /// add a new object to the namespace. We can then remove objects, freeing their memory, without

--- a/aml/src/opcode.rs
+++ b/aml/src/opcode.rs
@@ -42,10 +42,11 @@ pub const DEF_RETURN_OP: u8 = 0xa4;
 /*
  * Type 2 opcodes
  */
-pub const DEF_L_EQUAL_OP: u8 = 0x93;
 pub const DEF_STORE_OP: u8 = 0x70;
 pub const DEF_SHIFT_LEFT: u8 = 0x79;
 pub const DEF_SHIFT_RIGHT: u8 = 0x7a;
+pub const DEF_L_OR_OP: u8 = 0x91;
+pub const DEF_L_EQUAL_OP: u8 = 0x93;
 
 /*
  * Miscellaneous objects

--- a/aml/src/opcode.rs
+++ b/aml/src/opcode.rs
@@ -92,18 +92,18 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_utils::*, AmlError, DebugVerbosity};
+    use crate::{test_utils::*, AmlError};
 
     #[test]
     fn empty() {
-        let mut context = AmlContext::new(false, DebugVerbosity::None);
+        let mut context = crate::test_utils::make_test_context();
         check_err!(opcode(NULL_NAME).parse(&[], &mut context), AmlError::UnexpectedEndOfStream, &[]);
         check_err!(ext_opcode(EXT_DEF_FIELD_OP).parse(&[], &mut context), AmlError::UnexpectedEndOfStream, &[]);
     }
 
     #[test]
     fn simple_opcodes() {
-        let mut context = AmlContext::new(false, DebugVerbosity::None);
+        let mut context = crate::test_utils::make_test_context();
         check_ok!(opcode(DEF_SCOPE_OP).parse(&[DEF_SCOPE_OP], &mut context), (), &[]);
         check_ok!(
             opcode(DEF_NAME_OP).parse(&[DEF_NAME_OP, 0x31, 0x55, 0xf3], &mut context),
@@ -114,7 +114,7 @@ mod tests {
 
     #[test]
     fn extended_opcodes() {
-        let mut context = AmlContext::new(false, DebugVerbosity::None);
+        let mut context = crate::test_utils::make_test_context();
         check_err!(
             ext_opcode(EXT_DEF_FIELD_OP).parse(&[EXT_DEF_FIELD_OP, EXT_DEF_FIELD_OP], &mut context),
             AmlError::WrongParser,

--- a/aml/src/opcode.rs
+++ b/aml/src/opcode.rs
@@ -44,6 +44,8 @@ pub const DEF_RETURN_OP: u8 = 0xa4;
  */
 pub const DEF_L_EQUAL_OP: u8 = 0x93;
 pub const DEF_STORE_OP: u8 = 0x70;
+pub const DEF_SHIFT_LEFT: u8 = 0x79;
+pub const DEF_SHIFT_RIGHT: u8 = 0x7a;
 
 /*
  * Miscellaneous objects

--- a/aml/src/opcode.rs
+++ b/aml/src/opcode.rs
@@ -45,6 +45,7 @@ pub const DEF_RETURN_OP: u8 = 0xa4;
 pub const DEF_STORE_OP: u8 = 0x70;
 pub const DEF_SHIFT_LEFT: u8 = 0x79;
 pub const DEF_SHIFT_RIGHT: u8 = 0x7a;
+pub const DEF_AND_OP: u8 = 0x7b;
 pub const DEF_L_OR_OP: u8 = 0x91;
 pub const DEF_L_EQUAL_OP: u8 = 0x93;
 

--- a/aml/src/parser.rs
+++ b/aml/src/parser.rs
@@ -472,11 +472,11 @@ pub(crate) macro try_with_context($context: expr, $expr: expr) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_utils::*, DebugVerbosity};
+    use crate::test_utils::*;
 
     #[test]
     fn test_take_n() {
-        let mut context = AmlContext::new(false, DebugVerbosity::None);
+        let mut context = make_test_context();
         check_err!(take_n(1).parse(&[], &mut context), AmlError::UnexpectedEndOfStream, &[]);
         check_err!(take_n(2).parse(&[0xf5], &mut context), AmlError::UnexpectedEndOfStream, &[0xf5]);
 
@@ -487,7 +487,7 @@ mod tests {
 
     #[test]
     fn test_take_ux() {
-        let mut context = AmlContext::new(false, DebugVerbosity::None);
+        let mut context = make_test_context();
         check_err!(take_u16().parse(&[0x34], &mut context), AmlError::UnexpectedEndOfStream, &[0x34]);
         check_ok!(take_u16().parse(&[0x34, 0x12], &mut context), 0x1234, &[]);
 

--- a/aml/src/pci_routing.rs
+++ b/aml/src/pci_routing.rs
@@ -87,10 +87,10 @@ impl PciRoutingTable {
                      *   |            |           | pin is connected.                                         |
                      *   | -----------|-----------|-----------------------------------------------------------|
                      */
-                    let address = pin_package[0].as_integer()?;
+                    let address = pin_package[0].as_integer(context)?;
                     let device = address.get_bits(16..32).try_into().map_err(|_| AmlError::PrtInvalidAddress)?;
                     let function = address.get_bits(0..16).try_into().map_err(|_| AmlError::PrtInvalidAddress)?;
-                    let pin = match pin_package[1].as_integer()? {
+                    let pin = match pin_package[1].as_integer(context)? {
                         0 => Pin::IntA,
                         1 => Pin::IntB,
                         2 => Pin::IntC,
@@ -110,7 +110,7 @@ impl PciRoutingTable {
                                 pin,
                                 route_type: PciRouteType::Gsi(
                                     pin_package[3]
-                                        .as_integer()?
+                                        .as_integer(context)?
                                         .try_into()
                                         .map_err(|_| AmlError::PrtInvalidGsi)?,
                                 ),

--- a/aml/src/pkg_length.rs
+++ b/aml/src/pkg_length.rs
@@ -91,10 +91,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_utils::*, AmlError, DebugVerbosity};
+    use crate::{test_utils::*, AmlError};
 
     fn test_correct_pkglength(stream: &[u8], expected_raw_length: u32, expected_leftover: &[u8]) {
-        let mut context = AmlContext::new(false, DebugVerbosity::None);
+        let mut context = make_test_context();
         check_ok!(
             pkg_length().parse(stream, &mut context),
             PkgLength::from_raw_length(stream, expected_raw_length),
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn test_raw_pkg_length() {
-        let mut context = AmlContext::new(false, DebugVerbosity::None);
+        let mut context = make_test_context();
         check_ok!(raw_pkg_length().parse(&[0b01000101, 0x14], &mut context), 325, &[]);
         check_ok!(raw_pkg_length().parse(&[0b01000111, 0x14, 0x46], &mut context), 327, &[0x46]);
         check_ok!(raw_pkg_length().parse(&[0b10000111, 0x14, 0x46], &mut context), 287047, &[]);
@@ -112,7 +112,7 @@ mod tests {
 
     #[test]
     fn test_pkg_length() {
-        let mut context = AmlContext::new(false, DebugVerbosity::None);
+        let mut context = make_test_context();
         check_err!(pkg_length().parse(&[], &mut context), AmlError::UnexpectedEndOfStream, &[]);
         test_correct_pkglength(&[0x00], 0, &[]);
         test_correct_pkglength(&[0x05, 0xf5, 0x7f, 0x3e, 0x54, 0x03], 5, &[0xf5, 0x7f, 0x3e, 0x54, 0x03]);

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -487,7 +487,14 @@ where
                 (Ok(try_with_context!(context, context.current_arg(arg_num)).clone()), context)
             }),
             local_obj().map_with_context(|local_num, context| {
-                (Ok(try_with_context!(context, context.local(local_num)).clone()), context)
+                (
+                    Ok(try_with_context!(
+                        context,
+                        context.local(local_num).ok_or(AmlError::InvalidLocalAccess(local_num))
+                    )
+                    .clone()),
+                    context,
+                )
             }),
             make_parser_concrete!(type2_opcode())
         ),

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -210,13 +210,20 @@ where
                         Ok(length) => length,
                         Err(err) => return (Err(err), context),
                     };
+                    let parent_device = match region {
+                        RegionSpace::PciConfig | RegionSpace::IPMI | RegionSpace::GenericSerialBus => {
+                            let resolved_path = try_with_context!(context, name.resolve(&context.current_scope));
+                            Some(try_with_context!(context, resolved_path.parent()))
+                        }
+                        _ => None,
+                    };
 
                     try_with_context!(
                         context,
                         context.namespace.add_value_at_resolved_path(
                             name,
                             &context.current_scope,
-                            AmlValue::OpRegion { region, offset, length }
+                            AmlValue::OpRegion { region, offset, length, parent_device }
                         )
                     );
                     (Ok(()), context)

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -498,14 +498,7 @@ where
                 (Ok(try_with_context!(context, context.current_arg(arg_num)).clone()), context)
             }),
             local_obj().map_with_context(|local_num, context| {
-                (
-                    Ok(try_with_context!(
-                        context,
-                        context.local(local_num).ok_or(AmlError::InvalidLocalAccess(local_num))
-                    )
-                    .clone()),
-                    context,
-                )
+                (Ok(try_with_context!(context, context.local(local_num)).clone()), context)
             }),
             make_parser_concrete!(type2_opcode())
         ),

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -22,6 +22,7 @@ use crate::{
     value::{AmlValue, FieldFlags, MethodFlags, RegionSpace},
     AmlContext,
     AmlError,
+    AmlHandle,
     DebugVerbosity,
 };
 use alloc::string::String;
@@ -233,11 +234,21 @@ where
      * DefField = ExtOpPrefix 0x81 PkgLength NameString FieldFlags FieldList
      * FieldFlags := ByteData
      */
+    let opregion_as_handle = name_string().map_with_context(|region_name, context| {
+        /*
+         * We search for the opregion that this field is referencing here as we already have the correct starting
+         * scope. If we leave this to later, it becomes much harder as we also need to know the field's scope.
+         */
+        let (_, handle) =
+            try_with_context!(context, context.namespace.search(&region_name, &context.current_scope));
+        (Ok(handle), context)
+    });
+
     ext_opcode(opcode::EXT_DEF_FIELD_OP)
         .then(comment_scope(
             DebugVerbosity::Scopes,
             "DefField",
-            pkg_length().then(name_string()).then(take()).feed(|((list_length, region_name), flags)| {
+            pkg_length().then(opregion_as_handle).then(take()).feed(|((list_length, region_handle), flags)| {
                 move |mut input: &'a [u8], mut context: &'c mut AmlContext| -> ParseResult<'a, 'c, ()> {
                     /*
                      * FieldList := Nothing | <FieldElement FieldList>
@@ -246,7 +257,7 @@ where
                     let mut current_offset = 0;
                     while list_length.still_parsing(input) {
                         let (new_input, new_context, field_length) =
-                            field_element(region_name.clone(), FieldFlags::new(flags), current_offset)
+                            field_element(region_handle, FieldFlags::new(flags), current_offset)
                                 .parse(input, context)?;
                         input = new_input;
                         context = new_context;
@@ -263,7 +274,7 @@ where
 /// Parses a `FieldElement`. Takes the current offset within the field list, and returns the length
 /// of the field element parsed.
 pub fn field_element<'a, 'c>(
-    region_name: AmlName,
+    region_handle: AmlHandle,
     flags: FieldFlags,
     current_offset: u64,
 ) -> impl Parser<'a, 'c, u64>
@@ -308,7 +319,7 @@ where
                 AmlName::from_name_seg(name_seg),
                 &context.current_scope,
                 AmlValue::Field {
-                    region: region_name.clone(),
+                    region: region_handle,
                     flags,
                     offset: current_offset,
                     length: length.raw_length as u64,

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -202,11 +202,11 @@ where
                         space @ 0x80..=0xff => RegionSpace::OemDefined(space),
                         byte => return (Err(AmlError::InvalidRegionSpace(byte)), context),
                     };
-                    let offset = match offset.as_integer() {
+                    let offset = match offset.as_integer(context) {
                         Ok(offset) => offset,
                         Err(err) => return (Err(err), context),
                     };
-                    let length = match length.as_integer() {
+                    let length = match length.as_integer(context) {
                         Ok(length) => length,
                         Err(err) => return (Err(err), context),
                     };

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -605,11 +605,11 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{test_utils::*, AmlContext, DebugVerbosity};
+    use crate::test_utils::*;
 
     #[test]
     fn test_computational_data() {
-        let mut context = AmlContext::new(false, DebugVerbosity::None);
+        let mut context = make_test_context();
         check_ok!(
             computational_data().parse(&[0x00, 0x34, 0x12], &mut context),
             AmlValue::Integer(0),

--- a/aml/src/test_utils.rs
+++ b/aml/src/test_utils.rs
@@ -1,8 +1,84 @@
+use crate::{AmlContext, Handler};
+use alloc::boxed::Box;
+
+struct TestHandler;
+
+impl Handler for TestHandler {
+    fn read_u8(&self, _address: usize) -> u8 {
+        unimplemented!()
+    }
+    fn read_u16(&self, _address: usize) -> u16 {
+        unimplemented!()
+    }
+    fn read_u32(&self, _address: usize) -> u32 {
+        unimplemented!()
+    }
+    fn read_u64(&self, _address: usize) -> u64 {
+        unimplemented!()
+    }
+
+    fn write_u8(&mut self, _address: usize, _value: u8) {
+        unimplemented!()
+    }
+    fn write_u16(&mut self, _address: usize, _value: u16) {
+        unimplemented!()
+    }
+    fn write_u32(&mut self, _address: usize, _value: u32) {
+        unimplemented!()
+    }
+    fn write_u64(&mut self, _address: usize, _value: u64) {
+        unimplemented!()
+    }
+
+    fn read_io_u8(&self, _port: u16) -> u8 {
+        unimplemented!()
+    }
+    fn read_io_u16(&self, _port: u16) -> u16 {
+        unimplemented!()
+    }
+    fn read_io_u32(&self, _port: u16) -> u32 {
+        unimplemented!()
+    }
+
+    fn write_io_u8(&self, _port: u16, _value: u8) {
+        unimplemented!()
+    }
+    fn write_io_u16(&self, _port: u16, _value: u16) {
+        unimplemented!()
+    }
+    fn write_io_u32(&self, _port: u16, _value: u32) {
+        unimplemented!()
+    }
+
+    fn read_pci_u8(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16) -> u8 {
+        unimplemented!()
+    }
+    fn read_pci_u16(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16) -> u16 {
+        unimplemented!()
+    }
+    fn read_pci_u32(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16) -> u32 {
+        unimplemented!()
+    }
+    fn write_pci_u8(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16, _value: u8) {
+        unimplemented!()
+    }
+    fn write_pci_u16(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16, _value: u16) {
+        unimplemented!()
+    }
+    fn write_pci_u32(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16, _value: u32) {
+        unimplemented!()
+    }
+}
+
+pub(crate) fn make_test_context() -> AmlContext {
+    AmlContext::new(Box::new(TestHandler), false, crate::DebugVerbosity::None)
+}
+
 pub(crate) macro check_err($parse: expr, $error: pat, $remains: expr) {
     match $parse {
-        Ok(result) => panic!("Expected Err, got {:#?}", result),
+        Ok((remains, _, result)) => panic!("Expected Err, got {:#?}. Remaining = {:#x?}", result, remains),
         Err((remains, _, $error)) if *remains == *$remains => (),
-        Err((remains, _, $error)) => panic!("Correct error, incorrect stream returned: {:x?}", remains),
+        Err((remains, _, $error)) => panic!("Correct error, incorrect stream returned: {:#x?}", remains),
         Err((_, _, err)) => panic!("Got wrong error: {:?}", err),
     }
 }
@@ -13,7 +89,7 @@ pub(crate) macro check_ok($parse: expr, $expected: expr, $remains: expr) {
         Ok((remains, _, ref result)) if result == &$expected => {
             panic!("Correct result, incorrect slice returned: {:x?}", remains)
         }
-        Ok(result) => panic!("Successfully parsed Ok, but it was wrong: {:#?}", result),
+        Ok((_, _, ref result)) => panic!("Successfully parsed Ok, but it was wrong: {:#?}", result),
         Err((_, _, err)) => panic!("Expected Ok, got {:#?}", err),
     }
 }

--- a/aml/src/type2.rs
+++ b/aml/src/type2.rs
@@ -44,6 +44,7 @@ where
         choice!(
             def_buffer(),
             def_l_equal(),
+            def_l_or(),
             def_package(),
             def_shift_left(),
             def_shift_right(),
@@ -77,6 +78,27 @@ where
             }),
         ))
         .map(|((), (bytes, buffer_size))| Ok(AmlValue::Buffer { bytes, size: buffer_size }))
+}
+
+fn def_l_or<'a, 'c>() -> impl Parser<'a, 'c, AmlValue>
+where
+    'c: 'a,
+{
+    /*
+     * DefLOr := 0x91 Operand Operand
+     * Operand := TermArg => Integer
+     */
+    opcode(opcode::DEF_L_OR_OP)
+        .then(comment_scope(
+            DebugVerbosity::AllScopes,
+            "DefLOr",
+            term_arg().then(term_arg()).map_with_context(|(left_arg, right_arg), context| {
+                let left = try_with_context!(context, left_arg.as_bool());
+                let right = try_with_context!(context, right_arg.as_bool());
+                (Ok(AmlValue::Boolean(left || right)), context)
+            }),
+        ))
+        .map(|((), result)| Ok(result))
 }
 
 fn def_l_equal<'a, 'c>() -> impl Parser<'a, 'c, AmlValue>

--- a/aml/src/type2.rs
+++ b/aml/src/type2.rs
@@ -1,5 +1,5 @@
 use crate::{
-    name_object::{name_string, super_name, Target},
+    name_object::{name_string, super_name, target},
     opcode::{self, opcode},
     parser::{choice, comment_scope, id, take, take_to_end_of_pkglength, try_with_context, Parser},
     pkg_length::pkg_length,
@@ -132,32 +132,7 @@ where
     opcode(opcode::DEF_STORE_OP)
         .then(comment_scope(DebugVerbosity::Scopes, "DefStore", term_arg().then(super_name())))
         .map_with_context(|((), (value, target)), context| {
-            match target {
-                Target::Name(ref path) => {
-                    let (_, handle) =
-                        try_with_context!(context, context.namespace.search(path, &context.current_scope));
-                    let desired_type = context.namespace.get(handle).unwrap().type_of();
-                    let converted_object = try_with_context!(context, value.as_type(desired_type));
-
-                    *try_with_context!(context, context.namespace.get_mut(handle)) = converted_object;
-                    (Ok(context.namespace.get(handle).unwrap().clone()), context)
-                }
-
-                Target::Debug => {
-                    // TODO
-                    unimplemented!()
-                }
-
-                Target::Arg(arg_num) => {
-                    // TODO
-                    unimplemented!()
-                }
-
-                Target::Local(local_num) => {
-                    // TODO
-                    unimplemented!()
-                }
-            }
+            (Ok(try_with_context!(context, context.store(target, value))), context)
         })
 }
 

--- a/aml/src/type2.rs
+++ b/aml/src/type2.rs
@@ -138,6 +138,11 @@ where
             DebugVerbosity::AllScopes,
             "DefLEqual",
             term_arg().then(term_arg()).map_with_context(|(left_arg, right_arg), context| {
+                /*
+                 * TODO: we should also be able to compare strings and buffers. `left_arg` decides the type that we
+                 * need to use - we have to try and convert `right_arg` into that type and then compare them in the
+                 * correct way.
+                 */
                 let left = try_with_context!(context, left_arg.as_integer(context));
                 let right = try_with_context!(context, right_arg.as_integer(context));
                 (Ok(AmlValue::Boolean(left == right)), context)

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -1,4 +1,4 @@
-use crate::{misc::ArgNum, namespace::AmlName, AmlError};
+use crate::{misc::ArgNum, AmlContext, AmlError, AmlHandle};
 use alloc::{string::String, vec::Vec};
 use bit_field::BitField;
 
@@ -146,7 +146,7 @@ pub enum AmlValue {
     Integer(u64),
     String(String),
     OpRegion { region: RegionSpace, offset: u64, length: u64 },
-    Field { region: AmlName, flags: FieldFlags, offset: u64, length: u64 },
+    Field { region: AmlHandle, flags: FieldFlags, offset: u64, length: u64 },
     Method { flags: MethodFlags, code: Vec<u8> },
     Buffer { bytes: Vec<u8>, size: u64 },
     Processor { id: u8, pblk_address: u32, pblk_len: u8 },

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -321,6 +321,19 @@ pub struct Args {
 }
 
 impl Args {
+    pub fn from_list(mut list: Vec<AmlValue>) -> Args {
+        assert!(list.len() <= 7);
+        list.reverse();
+        Args {
+            arg_0: list.pop(),
+            arg_1: list.pop(),
+            arg_2: list.pop(),
+            arg_3: list.pop(),
+            arg_4: list.pop(),
+            arg_5: list.pop(),
+            arg_6: list.pop(),
+        }
+    }
     /// Get an argument by its `ArgNum`.
     ///
     /// ### Panics

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -178,7 +178,7 @@ impl AmlValue {
         }
     }
 
-    pub fn as_integer(&self) -> Result<u64, AmlError> {
+    pub fn as_integer(&self, context: &AmlContext) -> Result<u64, AmlError> {
         match self {
             AmlValue::Integer(value) => Ok(*value),
 
@@ -241,7 +241,7 @@ impl AmlValue {
     ///     `Integer` from: `Buffer`, `BufferField`, `DdbHandle`, `FieldUnit`, `String`, `Debug`
     ///     `Package` from: `Debug`
     ///     `String` from: `Integer`, `Buffer`, `Debug`
-    pub fn as_type(&self, desired_type: AmlType) -> Result<AmlValue, AmlError> {
+    pub fn as_type(&self, desired_type: AmlType, context: &AmlContext) -> Result<AmlValue, AmlError> {
         // Cache the type of this object
         let our_type = self.type_of();
 
@@ -252,7 +252,7 @@ impl AmlValue {
 
         // TODO: implement all of the rules
         match desired_type {
-            AmlType::Integer => self.as_integer().map(|value| AmlValue::Integer(value)),
+            AmlType::Integer => self.as_integer(context).map(|value| AmlValue::Integer(value)),
             _ => Err(AmlError::IncompatibleValueConversion),
         }
     }

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -295,92 +295,13 @@ impl AmlValue {
     /// depending on the size of the field.
     pub fn read_field(&self, context: &AmlContext) -> Result<AmlValue, AmlError> {
         if let AmlValue::Field { region, flags, offset, length } = self {
-            let (region_space, region_base, region_length, parent_device) = {
-                if let AmlValue::OpRegion { region, offset, length, parent_device } =
-                    context.namespace.get(*region)?
-                {
-                    (region, offset, length, parent_device)
-                } else {
-                    return Err(AmlError::FieldRegionIsNotOpRegion);
-                }
-            };
-
-            match region_space {
-                RegionSpace::SystemMemory => {
-                    let address = (region_base + offset).try_into().map_err(|_| AmlError::FieldInvalidAddress)?;
-                    match length {
-                        8 => Ok(AmlValue::Integer(context.handler.read_u8(address) as u64)),
-                        16 => Ok(AmlValue::Integer(context.handler.read_u16(address) as u64)),
-                        32 => Ok(AmlValue::Integer(context.handler.read_u32(address) as u64)),
-                        64 => Ok(AmlValue::Integer(context.handler.read_u64(address))),
-                        _ => Err(AmlError::FieldInvalidAccessSize),
-                    }
-                }
-
-                RegionSpace::SystemIo => {
-                    let port = (region_base + offset).try_into().map_err(|_| AmlError::FieldInvalidAddress)?;
-                    match length {
-                        8 => Ok(AmlValue::Integer(context.handler.read_io_u8(port) as u64)),
-                        16 => Ok(AmlValue::Integer(context.handler.read_io_u16(port) as u64)),
-                        32 => Ok(AmlValue::Integer(context.handler.read_io_u32(port) as u64)),
-                        _ => Err(AmlError::FieldInvalidAccessSize),
-                    }
-                }
-
-                RegionSpace::PciConfig => {
-                    /*
-                     * First, we need to get some extra information out of objects in the parent object. Both
-                     * `_SEG` and `_BBN` seem optional, with defaults that line up with legacy PCI implementations
-                     * (e.g. systems with a single segment group and a single root, respectively).
-                     */
-                    let parent_device = parent_device.as_ref().unwrap();
-                    let seg = match context.namespace.search(&AmlName::from_str("_SEG").unwrap(), parent_device) {
-                        Ok((_, handle)) => context
-                            .namespace
-                            .get(handle)?
-                            .as_integer(context)?
-                            .try_into()
-                            .map_err(|_| AmlError::FieldInvalidAddress)?,
-                        Err(AmlError::ValueDoesNotExist(_)) => 0,
-                        Err(err) => return Err(err),
-                    };
-                    let bbn = match context.namespace.search(&AmlName::from_str("_BBN").unwrap(), parent_device) {
-                        Ok((_, handle)) => context
-                            .namespace
-                            .get(handle)?
-                            .as_integer(context)?
-                            .try_into()
-                            .map_err(|_| AmlError::FieldInvalidAddress)?,
-                        Err(AmlError::ValueDoesNotExist(_)) => 0,
-                        Err(err) => return Err(err),
-                    };
-                    let adr = {
-                        let (_, handle) =
-                            context.namespace.search(&AmlName::from_str("_ADR").unwrap(), parent_device)?;
-                        context.namespace.get(handle)?.as_integer(context)?
-                    };
-
-                    let device = adr.get_bits(16..24) as u8;
-                    let function = adr.get_bits(0..8) as u8;
-                    let offset = (region_base + offset).try_into().map_err(|_| AmlError::FieldInvalidAddress)?;
-
-                    match length {
-                        8 => Ok(AmlValue::Integer(
-                            context.handler.read_pci_u8(seg, bbn, device, function, offset) as u64,
-                        )),
-                        16 => Ok(AmlValue::Integer(
-                            context.handler.read_pci_u16(seg, bbn, device, function, offset) as u64,
-                        )),
-                        32 => Ok(AmlValue::Integer(
-                            context.handler.read_pci_u32(seg, bbn, device, function, offset) as u64,
-                        )),
-                        _ => Err(AmlError::FieldInvalidAccessSize),
-                    }
-                }
-
-                // TODO
-                _ => unimplemented!(),
-            }
+            /*
+             * TODO: we need to decide properly how to read from the region itself. Complications:
+             *    - if the region has a minimum access size greater than the desired length, we need to read the
+             *      minimum and mask it (reading a byte from a WordAcc region)
+             *    - if the desired length is larger than we can read, we need to do multiple reads
+             */
+            Ok(AmlValue::Integer(context.read_region(*region, *offset, *length)?))
         } else {
             Err(AmlError::IncompatibleValueConversion)
         }

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -102,19 +102,19 @@ pub struct StatusObject {
     /// Whether the device is physically present. If this is `false`, `enabled` should also be `false` (i.e. a
     /// device that is not present can't be enabled). However, this is not enforced here if the firmware is doing
     /// something wrong.
-    present: bool,
+    pub present: bool,
     /// Whether the device is enabled. Both `present` and `enabled` must be `true` for the device to decode its
     /// hardware resources.
-    enabled: bool,
-    show_in_ui: bool,
-    functioning: bool,
+    pub enabled: bool,
+    pub show_in_ui: bool,
+    pub functional: bool,
     /// Only applicable for Control Method Battery Devices (`PNP0C0A`). For all other devices, ignore this value.
-    battery_present: bool,
+    pub battery_present: bool,
 }
 
 impl Default for StatusObject {
     fn default() -> Self {
-        StatusObject { present: true, enabled: true, show_in_ui: true, functioning: true, battery_present: true }
+        StatusObject { present: true, enabled: true, show_in_ui: true, functional: true, battery_present: true }
     }
 }
 
@@ -255,7 +255,7 @@ impl AmlValue {
                     present: value.get_bit(0),
                     enabled: value.get_bit(1),
                     show_in_ui: value.get_bit(2),
-                    functioning: value.get_bit(3),
+                    functional: value.get_bit(3),
                     battery_present: value.get_bit(4),
                 })
             }

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -277,14 +277,14 @@ impl Args {
     /// Panics if passed an invalid argument number (valid argument numbers are `0..=6`)
     pub fn arg(&self, num: ArgNum) -> Result<&AmlValue, AmlError> {
         match num {
-            0 => self.arg_0.as_ref().ok_or(AmlError::InvalidArgumentAccess(num)),
-            1 => self.arg_1.as_ref().ok_or(AmlError::InvalidArgumentAccess(num)),
-            2 => self.arg_2.as_ref().ok_or(AmlError::InvalidArgumentAccess(num)),
-            3 => self.arg_3.as_ref().ok_or(AmlError::InvalidArgumentAccess(num)),
-            4 => self.arg_4.as_ref().ok_or(AmlError::InvalidArgumentAccess(num)),
-            5 => self.arg_5.as_ref().ok_or(AmlError::InvalidArgumentAccess(num)),
-            6 => self.arg_6.as_ref().ok_or(AmlError::InvalidArgumentAccess(num)),
-            _ => panic!("Invalid argument number: {}", num),
+            0 => self.arg_0.as_ref().ok_or(AmlError::InvalidArgAccess(num)),
+            1 => self.arg_1.as_ref().ok_or(AmlError::InvalidArgAccess(num)),
+            2 => self.arg_2.as_ref().ok_or(AmlError::InvalidArgAccess(num)),
+            3 => self.arg_3.as_ref().ok_or(AmlError::InvalidArgAccess(num)),
+            4 => self.arg_4.as_ref().ok_or(AmlError::InvalidArgAccess(num)),
+            5 => self.arg_5.as_ref().ok_or(AmlError::InvalidArgAccess(num)),
+            6 => self.arg_6.as_ref().ok_or(AmlError::InvalidArgAccess(num)),
+            _ => Err(AmlError::InvalidArgAccess(num)),
         }
     }
 }

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -175,6 +175,7 @@ impl AmlValue {
     pub fn as_bool(&self) -> Result<bool, AmlError> {
         match self {
             AmlValue::Boolean(value) => Ok(*value),
+            AmlValue::Integer(value) => Ok(*value != 0),
             _ => Err(AmlError::IncompatibleValueConversion),
         }
     }

--- a/aml_tester/src/main.rs
+++ b/aml_tester/src/main.rs
@@ -196,4 +196,13 @@ impl aml::Handler for Handler {
     fn read_pci_u32(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
         unimplemented!()
     }
+    fn write_pci_u8(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16, value: u8) {
+        unimplemented!()
+    }
+    fn write_pci_u16(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16, value: u16) {
+        unimplemented!()
+    }
+    fn write_pci_u32(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16, value: u32) {
+        unimplemented!()
+    }
 }

--- a/aml_tester/src/main.rs
+++ b/aml_tester/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> std::io::Result<()> {
         file.read_to_end(&mut contents).unwrap();
 
         const AML_TABLE_HEADER_LENGTH: usize = 36;
-        let mut context = AmlContext::new(false, DebugVerbosity::None);
+        let mut context = AmlContext::new(Box::new(Handler), false, DebugVerbosity::None);
 
         match context.parse_table(&contents[AML_TABLE_HEADER_LENGTH..]) {
             Ok(()) => {
@@ -135,5 +135,55 @@ impl log::Log for Logger {
 
     fn flush(&self) {
         std::io::stdout().flush().unwrap();
+    }
+}
+
+struct Handler;
+
+impl aml::Handler for Handler {
+    fn read_u8(&self, address: usize) -> u8 {
+        unimplemented!()
+    }
+    fn read_u16(&self, address: usize) -> u16 {
+        unimplemented!()
+    }
+    fn read_u32(&self, address: usize) -> u32 {
+        unimplemented!()
+    }
+    fn read_u64(&self, address: usize) -> u64 {
+        unimplemented!()
+    }
+
+    fn write_u8(&mut self, address: usize, value: u8) {
+        unimplemented!()
+    }
+    fn write_u16(&mut self, address: usize, value: u16) {
+        unimplemented!()
+    }
+    fn write_u32(&mut self, address: usize, value: u32) {
+        unimplemented!()
+    }
+    fn write_u64(&mut self, address: usize, value: u64) {
+        unimplemented!()
+    }
+
+    fn read_io_u8(&self, port: u16) -> u8 {
+        unimplemented!()
+    }
+    fn read_io_u16(&self, port: u16) -> u16 {
+        unimplemented!()
+    }
+    fn read_io_u32(&self, port: u16) -> u32 {
+        unimplemented!()
+    }
+
+    fn write_io_u8(&self, port: u16, value: u8) {
+        unimplemented!()
+    }
+    fn write_io_u16(&self, port: u16, value: u16) {
+        unimplemented!()
+    }
+    fn write_io_u32(&self, port: u16, value: u32) {
+        unimplemented!()
     }
 }

--- a/aml_tester/src/main.rs
+++ b/aml_tester/src/main.rs
@@ -141,68 +141,68 @@ impl log::Log for Logger {
 struct Handler;
 
 impl aml::Handler for Handler {
-    fn read_u8(&self, address: usize) -> u8 {
+    fn read_u8(&self, _address: usize) -> u8 {
         unimplemented!()
     }
-    fn read_u16(&self, address: usize) -> u16 {
+    fn read_u16(&self, _address: usize) -> u16 {
         unimplemented!()
     }
-    fn read_u32(&self, address: usize) -> u32 {
+    fn read_u32(&self, _address: usize) -> u32 {
         unimplemented!()
     }
-    fn read_u64(&self, address: usize) -> u64 {
-        unimplemented!()
-    }
-
-    fn write_u8(&mut self, address: usize, value: u8) {
-        unimplemented!()
-    }
-    fn write_u16(&mut self, address: usize, value: u16) {
-        unimplemented!()
-    }
-    fn write_u32(&mut self, address: usize, value: u32) {
-        unimplemented!()
-    }
-    fn write_u64(&mut self, address: usize, value: u64) {
+    fn read_u64(&self, _address: usize) -> u64 {
         unimplemented!()
     }
 
-    fn read_io_u8(&self, port: u16) -> u8 {
+    fn write_u8(&mut self, _address: usize, _value: u8) {
         unimplemented!()
     }
-    fn read_io_u16(&self, port: u16) -> u16 {
+    fn write_u16(&mut self, _address: usize, _value: u16) {
         unimplemented!()
     }
-    fn read_io_u32(&self, port: u16) -> u32 {
+    fn write_u32(&mut self, _address: usize, _value: u32) {
         unimplemented!()
     }
-
-    fn write_io_u8(&self, port: u16, value: u8) {
-        unimplemented!()
-    }
-    fn write_io_u16(&self, port: u16, value: u16) {
-        unimplemented!()
-    }
-    fn write_io_u32(&self, port: u16, value: u32) {
+    fn write_u64(&mut self, _address: usize, _value: u64) {
         unimplemented!()
     }
 
-    fn read_pci_u8(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u8 {
+    fn read_io_u8(&self, _port: u16) -> u8 {
         unimplemented!()
     }
-    fn read_pci_u16(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u16 {
+    fn read_io_u16(&self, _port: u16) -> u16 {
         unimplemented!()
     }
-    fn read_pci_u32(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
+    fn read_io_u32(&self, _port: u16) -> u32 {
         unimplemented!()
     }
-    fn write_pci_u8(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16, value: u8) {
+
+    fn write_io_u8(&self, _port: u16, _value: u8) {
         unimplemented!()
     }
-    fn write_pci_u16(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16, value: u16) {
+    fn write_io_u16(&self, _port: u16, _value: u16) {
         unimplemented!()
     }
-    fn write_pci_u32(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16, value: u32) {
+    fn write_io_u32(&self, _port: u16, _value: u32) {
+        unimplemented!()
+    }
+
+    fn read_pci_u8(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16) -> u8 {
+        unimplemented!()
+    }
+    fn read_pci_u16(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16) -> u16 {
+        unimplemented!()
+    }
+    fn read_pci_u32(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16) -> u32 {
+        unimplemented!()
+    }
+    fn write_pci_u8(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16, _value: u8) {
+        unimplemented!()
+    }
+    fn write_pci_u16(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16, _value: u16) {
+        unimplemented!()
+    }
+    fn write_pci_u32(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16, _value: u32) {
         unimplemented!()
     }
 }

--- a/aml_tester/src/main.rs
+++ b/aml_tester/src/main.rs
@@ -186,4 +186,14 @@ impl aml::Handler for Handler {
     fn write_io_u32(&self, port: u16, value: u32) {
         unimplemented!()
     }
+
+    fn read_pci_u8(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u8 {
+        unimplemented!()
+    }
+    fn read_pci_u16(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u16 {
+        unimplemented!()
+    }
+    fn read_pci_u32(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
+        unimplemented!()
+    }
 }


### PR DESCRIPTION
When a table is loaded, OSPM should traverse the namespace and call the `_INI` method on devices that need to perform device-specific initialization. Apparently lots of modern hardware will completely fail to work in ACPI mode if this is not done, so we should probably support it sooner rather than later.

Evaluating `_STA` and `_INI` on QEMU's tables seems to use a bunch of opcodes that we don't support yet, so this also builds a bunch more support for that.

Adds support for:
- [x] Traversing the namespace
- [x] Take a handler ffor asking OSPM for stuff
- [x] Allow reading from `SystemMemory` operation regions
- [x] Allow reading from `SystemIO` operation regions
- [x] Stores to locals and argument objects
- [x] Performing field reads as implicit conversions to `Integers`s
- [x] Evaluating and interpreting `_STA` status objects
- [x] `Target`
- [x] `DefShiftLeft`
- [x] `DefShiftRight`
- [x] `DefLOr`
- [x] Invoking methods from within other methods
- [x] `DefAnd`
- [x] Allow reading from `PCIConfig` operation regions
- [x] Execute `_INI` for present devices that have it
- [x] Correctly traverse sub-devices when a device is present or functional
- [x] Handle weird-sized field accesses
- [x] Handle writes to op-regions
- [x] Fix tests