### PR TITLE
feat: add `PmTimer`

### DIFF
--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -152,6 +152,8 @@ impl PmTimer {
                 .ok_or(AcpiError::TableMissing(crate::sdt::Signature::FADT))?
         };
 
-        Ok(PmTimer { io_base: fadt.pm_timer_block, supports_32bit: fadt.flags.get_bit(8) })
+        let flags = fadt.flags;
+
+        Ok(PmTimer { io_base: fadt.pm_timer_block, supports_32bit: flags.get_bit(8) })
     }
 }

--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -130,10 +130,6 @@ impl Fadt {
             other => PowerProfile::Reserved(other),
         }
     }
-
-    pub fn pm_timer(&self) -> PmTimer {
-        PmTimer { io_base: self.pm_timer_block, supports_32bit: self.flags.get_bit(8) }
-    }
 }
 
 /// Information about the ACPI Power Management Timer (ACPI PM Timer).

--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -131,7 +131,7 @@ impl Fadt {
         }
     }
 
-    pub fn pm_timer_block(&self) -> Result<Option<GenericAddress>, AcpiError> {
+    fn pm_timer_block(&self) -> Result<Option<GenericAddress>, AcpiError> {
         let raw = unsafe {
             self.x_pm_timer_block.access(self.header().revision).or_else(|| {
                 if self.pm_timer_block != 0 {

--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -70,7 +70,7 @@ pub struct Fadt {
     century: u8,
     iapc_boot_arch: u16,
     _reserved2: u8, // must be 0
-    flags: u32,
+    pub flags: u32,
     reset_reg: RawGenericAddress,
     reset_value: u8,
     arm_boot_arch: u16,
@@ -149,9 +149,5 @@ impl Fadt {
             Some(raw) => Ok(Some(GenericAddress::from_raw(raw)?)),
             None => Ok(None),
         }
-    }
-
-    pub fn flags(&self) -> u32 {
-        self.flags
     }
 }

--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -133,7 +133,7 @@ impl Fadt {
             self.x_pm_timer_block.access(self.header().revision).or_else(|| {
                 if self.pm_timer_block != 0 {
                     Some(RawGenericAddress {
-                        address_space: 0,
+                        address_space: 1,
                         bit_width: 0,
                         bit_offset: 0,
                         access_size: self.pm_timer_length,

--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -134,7 +134,7 @@ impl Fadt {
 
 /// Information about the ACPI Power Management Timer (ACPI PM Timer).
 pub struct PmTimer {
-    /// An I/O space address to the register of ACPI PM Timer.
+    /// An I/O space address to the register block of ACPI PM Timer.
     pub io_base: u32,
     /// This field is true if the hardware supports 32-bit timer, and false if the hardware
     /// supports 24-bit timer.

--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -4,7 +4,6 @@ use crate::{
     AcpiError,
     AcpiTable,
 };
-use bit_field::BitField;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum PowerProfile {
@@ -129,11 +128,7 @@ impl Fadt {
         }
     }
 
-    pub fn pm_timer(&self) -> Result<Option<PmTimer>, AcpiError> {
-        PmTimer::new(self)
-    }
-
-    fn pm_timer_block(&self) -> Result<Option<GenericAddress>, AcpiError> {
+    pub fn pm_timer_block(&self) -> Result<Option<GenericAddress>, AcpiError> {
         let raw = unsafe {
             self.x_pm_timer_block.access(self.header().revision).or_else(|| {
                 if self.pm_timer_block != 0 {
@@ -155,25 +150,8 @@ impl Fadt {
             None => Ok(None),
         }
     }
-}
 
-/// Information about the ACPI Power Management Timer (ACPI PM Timer).
-pub struct PmTimer {
-    /// A generic address to the register block of ACPI PM Timer.
-    pub base: GenericAddress,
-    /// This field is true if the hardware supports 32-bit timer, and false if the hardware
-    /// supports 24-bit timer.
-    pub supports_32bit: bool,
-}
-impl PmTimer {
-    /// Creates a new instance of `PmTimer`.
-    pub fn new(fadt: &Fadt) -> Result<Option<PmTimer>, AcpiError> {
-        let base = fadt.pm_timer_block()?;
-        let flags = fadt.flags;
-
-        match base {
-            Some(base) => Ok(Some(PmTimer { base, supports_32bit: flags.get_bit(8) })),
-            None => Ok(None),
-        }
+    pub fn flags(&self) -> u32 {
+        self.flags
     }
 }

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -54,7 +54,7 @@ pub mod platform;
 pub mod sdt;
 
 pub use crate::{
-    fadt::PowerProfile,
+    fadt::{PmTimer, PowerProfile},
     hpet::HpetInfo,
     madt::MadtError,
     mcfg::PciConfigRegions,

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -54,7 +54,7 @@ pub mod platform;
 pub mod sdt;
 
 pub use crate::{
-    fadt::{PmTimer, PowerProfile},
+    fadt::PowerProfile,
     hpet::HpetInfo,
     madt::MadtError,
     mcfg::PciConfigRegions,

--- a/acpi/src/platform/mod.rs
+++ b/acpi/src/platform/mod.rs
@@ -14,7 +14,7 @@ pub use interrupt::{
     TriggerMode,
 };
 
-use crate::{fadt::Fadt, madt::Madt, AcpiError, AcpiHandler, AcpiTables, PowerProfile};
+use crate::{fadt::Fadt, madt::Madt, AcpiError, AcpiHandler, AcpiTables, PmTimer, PowerProfile};
 use alloc::vec::Vec;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -60,6 +60,7 @@ pub struct PlatformInfo {
     /// On `x86_64` platforms that support the APIC, the processor topology must also be inferred from the
     /// interrupt model. That information is stored here, if present.
     pub processor_info: Option<ProcessorInfo>,
+    pub pm_timer: Option<PmTimer>,
     /*
      * TODO: we could provide a nice view of the hardware register blocks in the FADT here.
      */
@@ -82,7 +83,8 @@ impl PlatformInfo {
             Some(madt) => madt.parse_interrupt_model()?,
             None => (InterruptModel::Unknown, None),
         };
+        let pm_timer = fadt.pm_timer()?;
 
-        Ok(PlatformInfo { power_profile, interrupt_model, processor_info })
+        Ok(PlatformInfo { power_profile, interrupt_model, processor_info, pm_timer })
     }
 }

--- a/acpi/src/platform/mod.rs
+++ b/acpi/src/platform/mod.rs
@@ -65,7 +65,7 @@ impl PmTimer {
     /// Creates a new instance of `PmTimer`.
     pub fn new(fadt: &Fadt) -> Result<Option<PmTimer>, AcpiError> {
         let base = fadt.pm_timer_block()?;
-        let flags = fadt.flags();
+        let flags = fadt.flags;
 
         match base {
             Some(base) => Ok(Some(PmTimer { base, supports_32bit: flags.get_bit(8) })),


### PR DESCRIPTION
This PR introduces a new struct called `PmTimer`, which contains the information of the ACPI Power Management Timer. It can be constructed from `AcpiTables`.