### PR TITLE
Reorganise to allow native methods, then implement them

### DIFF
--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -200,8 +200,8 @@ impl AmlContext {
                 {
                     // If the method doesn't return a value, we implicitly return `0`
                     Ok(_) => Ok(AmlValue::Integer(0)),
-                    Err((_, _, AmlError::Return(result))) => Ok(result),
-                    Err((_, _, err)) => {
+                    Err((_, _, Propagate::Return(result))) => Ok(result),
+                    Err((_, _, Propagate::Err(err))) => {
                         error!("Failed to execute control method: {:?}", err);
                         Err(err)
                     }
@@ -639,7 +639,7 @@ pub trait Handler {
     fn write_pci_u32(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16, value: u32);
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum AmlError {
     /*
      * Errors produced parsing the AML stream.
@@ -696,11 +696,6 @@ pub enum AmlError {
     InvalidArgAccess(ArgNum),
     /// Produced when a method accesses a local that it has not stored into.
     InvalidLocalAccess(LocalNum),
-    /// This is not a real error, but is used to propagate return values from within the deep
-    /// parsing call-stack. It should only be emitted when parsing a `DefReturn`. We use the
-    /// error system here because the way errors are propagated matches how we want to handle
-    /// return values.
-    Return(AmlValue),
 
     /*
      * Errors produced parsing the PCI routing tables (_PRT objects).

--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -561,6 +561,16 @@ impl AmlContext {
 
     fn add_predefined_objects(&mut self) {
         /*
+         * These are the scopes predefined by the spec. Some tables will try to access them without defining them
+         * themselves, and so we have to pre-create them.
+         */
+        self.namespace.add_level(AmlName::from_str("\\_GPE").unwrap(), LevelType::Scope).unwrap();
+        self.namespace.add_level(AmlName::from_str("\\_SB").unwrap(), LevelType::Scope).unwrap();
+        self.namespace.add_level(AmlName::from_str("\\_SI").unwrap(), LevelType::Scope).unwrap();
+        self.namespace.add_level(AmlName::from_str("\\_PR").unwrap(), LevelType::Scope).unwrap();
+        self.namespace.add_level(AmlName::from_str("\\_TZ").unwrap(), LevelType::Scope).unwrap();
+
+        /*
          * In the dark ages of ACPI 1.0, before `\_OSI`, `\_OS` was used to communicate to the firmware which OS
          * was running. This was predictably not very good, and so was replaced in ACPI 3.0 with `_OSI`, which
          * allows support for individual capabilities to be queried. `_OS` should not be used by modern firmwares,

--- a/aml/src/name_object.rs
+++ b/aml/src/name_object.rs
@@ -2,7 +2,7 @@ use crate::{
     misc::{arg_obj, debug_obj, local_obj, ArgNum, LocalNum},
     namespace::{AmlName, NameComponent},
     opcode::{opcode, DUAL_NAME_PREFIX, MULTI_NAME_PREFIX, NULL_NAME, PREFIX_CHAR, ROOT_CHAR},
-    parser::{choice, comment_scope, consume, n_of, take, take_while, Parser},
+    parser::{choice, comment_scope, consume, n_of, take, take_while, Parser, Propagate},
     AmlContext,
     AmlError,
     DebugVerbosity,
@@ -93,7 +93,7 @@ where
     comment_scope(DebugVerbosity::AllScopes, "NameString", move |input: &'a [u8], context| {
         let first_char = match input.first() {
             Some(&c) => c,
-            None => return Err((input, context, AmlError::UnexpectedEndOfStream)),
+            None => return Err((input, context, Propagate::Err(AmlError::UnexpectedEndOfStream))),
         };
 
         match first_char {
@@ -102,7 +102,7 @@ where
             _ => name_path()
                 .map(|path| {
                     if path.len() == 0 {
-                        return Err(AmlError::EmptyNamesAreInvalid);
+                        return Err(Propagate::Err(AmlError::EmptyNamesAreInvalid));
                     }
 
                     Ok(AmlName::from_components(path))

--- a/aml/src/namespace.rs
+++ b/aml/src/namespace.rs
@@ -543,6 +543,7 @@ impl NameComponent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::crudely_cmp_values;
 
     #[test]
     fn test_aml_name_from_str() {
@@ -677,16 +678,22 @@ mod tests {
         /*
          * Get objects using their absolute paths.
          */
-        assert_eq!(namespace.get_by_path(&AmlName::from_str("\\MOO").unwrap()), Ok(&AmlValue::Boolean(true)));
-        assert_eq!(
-            namespace.get_by_path(&AmlName::from_str("\\FOO.BAR.A").unwrap()),
-            Ok(&AmlValue::Integer(12345))
-        );
-        assert_eq!(namespace.get_by_path(&AmlName::from_str("\\FOO.BAR.B").unwrap()), Ok(&AmlValue::Integer(6)));
-        assert_eq!(
-            namespace.get_by_path(&AmlName::from_str("\\FOO.BAR.C").unwrap()),
-            Ok(&AmlValue::String(String::from("hello, world!")))
-        );
+        assert!(crudely_cmp_values(
+            namespace.get_by_path(&AmlName::from_str("\\MOO").unwrap()).unwrap(),
+            &AmlValue::Boolean(true)
+        ));
+        assert!(crudely_cmp_values(
+            namespace.get_by_path(&AmlName::from_str("\\FOO.BAR.A").unwrap()).unwrap(),
+            &AmlValue::Integer(12345)
+        ));
+        assert!(crudely_cmp_values(
+            namespace.get_by_path(&AmlName::from_str("\\FOO.BAR.B").unwrap()).unwrap(),
+            &AmlValue::Integer(6)
+        ));
+        assert!(crudely_cmp_values(
+            namespace.get_by_path(&AmlName::from_str("\\FOO.BAR.C").unwrap()).unwrap(),
+            &AmlValue::String(String::from("hello, world!"))
+        ));
 
         /*
          * Search for some objects that should use search rules.

--- a/aml/src/opcode.rs
+++ b/aml/src/opcode.rs
@@ -82,9 +82,9 @@ where
     'c: 'a,
 {
     move |input: &'a [u8], context: &'c mut AmlContext| match input.first() {
-        None => Err((input, context, AmlError::UnexpectedEndOfStream)),
+        None => Err((input, context, Propagate::Err(AmlError::UnexpectedEndOfStream))),
         Some(&byte) if byte == opcode => Ok((&input[1..], context, ())),
-        Some(_) => Err((input, context, AmlError::WrongParser)),
+        Some(_) => Err((input, context, Propagate::Err(AmlError::WrongParser))),
     }
 }
 

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -20,7 +20,7 @@ use crate::{
     pkg_length::{pkg_length, PkgLength},
     type1::type1_opcode,
     type2::{def_buffer, def_package, type2_opcode},
-    value::{AmlValue, FieldFlags, MethodFlags, RegionSpace},
+    value::{AmlValue, FieldFlags, MethodCode, MethodFlags, RegionSpace},
     AmlContext,
     AmlError,
     AmlHandle,
@@ -368,7 +368,10 @@ where
                         context.namespace.add_value_at_resolved_path(
                             name,
                             &context.current_scope,
-                            AmlValue::Method { flags: MethodFlags::new(flags), code: code.to_vec() },
+                            AmlValue::Method {
+                                flags: MethodFlags::new(flags),
+                                code: MethodCode::Aml(code.to_vec())
+                            },
                         )
                     );
                     (Ok(()), context)

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -612,40 +612,48 @@ mod test {
     #[test]
     fn test_computational_data() {
         let mut context = make_test_context();
-        check_ok!(
+        check_ok_value!(
             computational_data().parse(&[0x00, 0x34, 0x12], &mut context),
             AmlValue::Integer(0),
             &[0x34, 0x12]
         );
-        check_ok!(
+        check_ok_value!(
             computational_data().parse(&[0x01, 0x18, 0xf3], &mut context),
             AmlValue::Integer(1),
             &[0x18, 0xf3]
         );
-        check_ok!(
+        check_ok_value!(
             computational_data().parse(&[0xff, 0x98, 0xc3], &mut context),
             AmlValue::Integer(u64::max_value()),
             &[0x98, 0xc3]
         );
-        check_ok!(
+        check_ok_value!(
             computational_data().parse(&[0x5b, 0x30], &mut context),
             AmlValue::Integer(crate::AML_INTERPRETER_REVISION),
             &[]
         );
-        check_ok!(computational_data().parse(&[0x0a, 0xf3, 0x35], &mut context), AmlValue::Integer(0xf3), &[0x35]);
-        check_ok!(computational_data().parse(&[0x0b, 0xf3, 0x35], &mut context), AmlValue::Integer(0x35f3), &[]);
-        check_ok!(
+        check_ok_value!(
+            computational_data().parse(&[0x0a, 0xf3, 0x35], &mut context),
+            AmlValue::Integer(0xf3),
+            &[0x35]
+        );
+        check_ok_value!(
+            computational_data().parse(&[0x0b, 0xf3, 0x35], &mut context),
+            AmlValue::Integer(0x35f3),
+            &[]
+        );
+        check_ok_value!(
             computational_data().parse(&[0x0c, 0xf3, 0x35, 0x12, 0x65, 0xff, 0x00], &mut context),
             AmlValue::Integer(0x651235f3),
             &[0xff, 0x00]
         );
-        check_ok!(
+        check_ok_value!(
             computational_data()
                 .parse(&[0x0e, 0xf3, 0x35, 0x12, 0x65, 0xff, 0x00, 0x67, 0xde, 0x28], &mut context),
             AmlValue::Integer(0xde6700ff651235f3),
             &[0x28]
         );
-        check_ok!(
+        check_ok_value!(
             computational_data().parse(&[0x0d, b'A', b'B', b'C', b'D', b'\0', 0xff, 0xf5], &mut context),
             AmlValue::String(String::from("ABCD")),
             &[0xff, 0xf5]

--- a/aml/src/test_utils.rs
+++ b/aml/src/test_utils.rs
@@ -1,4 +1,4 @@
-use crate::{AmlContext, Handler};
+use crate::{parser::Propagate, AmlContext, AmlValue, Handler};
 use alloc::boxed::Box;
 
 struct TestHandler;
@@ -71,14 +71,16 @@ impl Handler for TestHandler {
 }
 
 pub(crate) fn make_test_context() -> AmlContext {
-    AmlContext::new(Box::new(TestHandler), false, crate::DebugVerbosity::None)
+    AmlContext::new(Box::new(TestHandler), crate::DebugVerbosity::None)
 }
 
 pub(crate) macro check_err($parse: expr, $error: pat, $remains: expr) {
     match $parse {
         Ok((remains, _, result)) => panic!("Expected Err, got {:#?}. Remaining = {:#x?}", result, remains),
-        Err((remains, _, $error)) if *remains == *$remains => (),
-        Err((remains, _, $error)) => panic!("Correct error, incorrect stream returned: {:#x?}", remains),
+        Err((remains, _, Propagate::Err($error))) if *remains == *$remains => (),
+        Err((remains, _, Propagate::Err($error))) => {
+            panic!("Correct error, incorrect stream returned: {:#x?}", remains)
+        }
         Err((_, _, err)) => panic!("Got wrong error: {:?}", err),
     }
 }
@@ -91,5 +93,88 @@ pub(crate) macro check_ok($parse: expr, $expected: expr, $remains: expr) {
         }
         Ok((_, _, ref result)) => panic!("Successfully parsed Ok, but it was wrong: {:#?}", result),
         Err((_, _, err)) => panic!("Expected Ok, got {:#?}", err),
+    }
+}
+
+pub(crate) macro check_ok_value($parse: expr, $expected: expr, $remains: expr) {
+    match $parse {
+        Ok((remains, _, ref result)) if remains == *$remains && crudely_cmp_values(result, &$expected) => (),
+        Ok((remains, _, ref result)) if crudely_cmp_values(result, &$expected) => {
+            panic!("Correct result, incorrect slice returned: {:x?}", remains)
+        }
+        Ok((_, _, ref result)) => panic!("Successfully parsed Ok, but it was wrong: {:#?}", result),
+        Err((_, _, err)) => panic!("Expected Ok, got {:#?}", err),
+    }
+}
+
+/// This is a bad (but good for testing) way of comparing `AmlValue`s, which tests that they're exactly the same if
+/// it can, and gives up if it can't. It's useful in tests to be able to see if you're getting the `AmlValue` that
+/// you're expecting.
+///
+/// NOTE: almost all of the `AmlValue` variants are `Eq`, and so for a long time, `AmlValue` implemented `Eq`.
+/// However, this is a footgun as, in the real interpreter, you rarely want to directly compare values, as you need
+/// to apply the AML value conversion rules to compare them correctly. This is therefore only useful for artificial
+/// testing scenarios.
+pub(crate) fn crudely_cmp_values(a: &AmlValue, b: &AmlValue) -> bool {
+    match a {
+        AmlValue::Boolean(a) => match b {
+            AmlValue::Boolean(b) => a == b,
+            _ => false,
+        },
+        AmlValue::Integer(a) => match b {
+            AmlValue::Integer(b) => a == b,
+            _ => false,
+        },
+        AmlValue::String(ref a) => match b {
+            AmlValue::String(ref b) => a == b,
+            _ => false,
+        },
+        AmlValue::OpRegion { region, offset, length, parent_device } => match b {
+            AmlValue::OpRegion {
+                region: b_region,
+                offset: b_offset,
+                length: b_length,
+                parent_device: b_parent_device,
+            } => {
+                region == b_region && offset == b_offset && length == b_length && parent_device == b_parent_device
+            }
+            _ => false,
+        },
+        AmlValue::Field { region, flags, offset, length } => match b {
+            AmlValue::Field { region: b_region, flags: b_flags, offset: b_offset, length: b_length } => {
+                region == b_region && flags == b_flags && offset == b_offset && length == b_length
+            }
+            _ => false,
+        },
+        AmlValue::Method { flags, code } => match b {
+            AmlValue::Method { flags: b_flags, code: b_code } => flags == b_flags && code == b_code,
+            _ => false,
+        },
+        AmlValue::Buffer(a) => match b {
+            AmlValue::Buffer(b) => a == b,
+            _ => false,
+        },
+        AmlValue::Processor { id, pblk_address, pblk_len } => match b {
+            AmlValue::Processor { id: b_id, pblk_address: b_pblk_address, pblk_len: b_pblk_len } => {
+                id == b_id && pblk_address == b_pblk_address && pblk_len == b_pblk_len
+            }
+            _ => false,
+        },
+        AmlValue::Mutex { sync_level } => match b {
+            AmlValue::Mutex { sync_level: b_sync_level } => sync_level == b_sync_level,
+            _ => false,
+        },
+        AmlValue::Package(a) => match b {
+            AmlValue::Package(b) => {
+                for (a, b) in a.iter().zip(b) {
+                    if crudely_cmp_values(a, b) == false {
+                        return false;
+                    }
+                }
+
+                true
+            }
+            _ => false,
+        },
     }
 }

--- a/aml/src/type1.rs
+++ b/aml/src/type1.rs
@@ -1,9 +1,8 @@
 use crate::{
     opcode::{self, opcode},
-    parser::{choice, comment_scope, id, take_to_end_of_pkglength, ParseResult, Parser},
+    parser::{choice, comment_scope, id, take_to_end_of_pkglength, ParseResult, Parser, Propagate},
     pkg_length::{pkg_length, PkgLength},
     term_object::{term_arg, term_list},
-    AmlError,
     DebugVerbosity,
 };
 
@@ -110,14 +109,14 @@ where
         .then(comment_scope(
             DebugVerbosity::Scopes,
             "DefReturn",
-            term_arg().map(|return_arg| -> Result<(), AmlError> {
+            term_arg().map(|return_arg| -> Result<(), Propagate> {
                 /*
                  * To return a value, we want to halt execution of the method and propagate the
                  * return value all the way up to the start of the method invocation. To do this,
                  * we emit a special error that is intercepted during method invocation and turned
                  * into a valid result.
                  */
-                Err(AmlError::Return(return_arg))
+                Err(Propagate::Return(return_arg))
             }),
         ))
         .discard_result()

--- a/aml/src/type2.rs
+++ b/aml/src/type2.rs
@@ -10,6 +10,7 @@ use crate::{
         take_to_end_of_pkglength,
         try_with_context,
         Parser,
+        Propagate,
     },
     pkg_length::pkg_length,
     term_object::{data_ref_object, term_arg},
@@ -134,7 +135,7 @@ where
                     let buffer_size = try_with_context!(context, buffer_size.as_integer(context)) as usize;
 
                     if buffer_size < bytes.len() {
-                        return (Err(AmlError::MalformedBuffer), context);
+                        return (Err(Propagate::Err(AmlError::MalformedBuffer)), context);
                     }
 
                     let mut buffer = vec![0; buffer_size];
@@ -312,7 +313,7 @@ where
                     }
 
                     if package_contents.len() != num_elements as usize {
-                        return Err((input, context, AmlError::MalformedPackage));
+                        return Err((input, context, Propagate::Err(AmlError::MalformedPackage)));
                     }
 
                     Ok((input, context, AmlValue::Package(package_contents)))

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -1,7 +1,7 @@
 use crate::{misc::ArgNum, AmlContext, AmlError, AmlHandle, AmlName};
-use alloc::{string::String, vec::Vec};
+use alloc::{rc::Rc, string::String, vec::Vec};
 use bit_field::BitField;
-use core::cmp;
+use core::{cmp, fmt, fmt::Debug};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum RegionSpace {
@@ -140,6 +140,21 @@ pub enum AmlType {
     ThermalZone,
 }
 
+#[derive(Clone)]
+pub enum MethodCode {
+    Aml(Vec<u8>),
+    Native(Rc<dyn Fn(&mut AmlContext) -> Result<AmlValue, AmlError>>),
+}
+
+impl fmt::Debug for MethodCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MethodCode::Aml(ref code) => f.debug_struct("AML method").field("code", code).finish(),
+            MethodCode::Native(_) => f.debug_struct("Native method").finish(),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum AmlValue {
     Boolean(bool),
@@ -163,7 +178,7 @@ pub enum AmlValue {
     },
     Method {
         flags: MethodFlags,
-        code: Vec<u8>,
+        code: MethodCode,
     },
     Buffer(Vec<u8>),
     Processor {

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -140,7 +140,7 @@ pub enum AmlType {
     ThermalZone,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Debug)]
 pub enum AmlValue {
     Boolean(bool),
     Integer(u64),

--- a/aml_tester/src/main.rs
+++ b/aml_tester/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> std::io::Result<()> {
         file.read_to_end(&mut contents).unwrap();
 
         const AML_TABLE_HEADER_LENGTH: usize = 36;
-        let mut context = AmlContext::new(Box::new(Handler), false, DebugVerbosity::None);
+        let mut context = AmlContext::new(Box::new(Handler), DebugVerbosity::None);
 
         match context.parse_table(&contents[AML_TABLE_HEADER_LENGTH..]) {
             Ok(()) => {


### PR DESCRIPTION
This PR makes the changes needed to allow AML methods to be defined natively (i.e. in Rust code, rather than in AML bytecode). This is useful for implementing methods such as `\_OSI`, but will also be useful in the future to allow method overrides for broken AML tables.

Allowing this change forces us to fix a couple of hacks we've been relying on, imposed by the fact that `AmlValue` (correctly) can no longer implement `PartialEq` or `Eq`. As values were previously stored in `AmlError`, predominantly to allow methods to return values (which were hackily propagated through the error system), this meant `AmlError` could also not be `Eq`, which would be inconvenient. Instead, we separate out the reasons to propagate a result using a new enum: `Propagate`. Getting here took a few attempts, but I think this is a clean way forward.

Having to do this work is actually good, as it cleans up one of the nastier corners of the interpreter, and also provides a nice way forward for other control flow situations needed by the interpreter (e.g. the `DefBreak` and `DefContinue` operations), without needing to expand the nasty fake error mechanism.

TODO:
- [x] Add `Propagate` and plumb it through the parser framework
- [x] Fix all the parsers
- [x] Make returning stuff work again, and remove old fake error system
- [x] Remove `PartialEq` and `Eq` implementations from `AmlValue`
- [x] Fix the fallout from that in the unit tests
- [x] Implement native functions