### PR TITLE
Record attempted conversion in AmlError::IncompatibleValueConversion

### DIFF
--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -713,7 +713,10 @@ pub enum AmlError {
     InvalidNameSeg,
     InvalidPkgLength,
     InvalidFieldFlags,
-    IncompatibleValueConversion,
+    IncompatibleValueConversion {
+        current: AmlType,
+        target: AmlType,
+    },
     UnterminatedStringConstant,
     InvalidStringConstant,
     InvalidRegionSpace(u8),

--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -778,6 +778,7 @@ pub enum AmlError {
     ReservedResourceType,
     ResourceDescriptorTooShort,
     ResourceDescriptorTooLong,
+    UnexpectedResourceType,
 
     /*
      * Errors produced working with AML values.

--- a/aml/src/pci_routing.rs
+++ b/aml/src/pci_routing.rs
@@ -4,6 +4,7 @@ use crate::{
     value::Args,
     AmlContext,
     AmlError,
+    AmlType,
     AmlValue,
 };
 use alloc::vec::Vec;
@@ -129,13 +130,16 @@ impl PciRoutingTable {
                         _ => return Err(AmlError::PrtInvalidSource),
                     }
                 } else {
-                    return Err(AmlError::IncompatibleValueConversion);
+                    return Err(AmlError::IncompatibleValueConversion {
+                        current: value.type_of(),
+                        target: AmlType::Package,
+                    });
                 }
             }
 
             Ok(PciRoutingTable { entries })
         } else {
-            Err(AmlError::IncompatibleValueConversion)
+            Err(AmlError::IncompatibleValueConversion { current: prt.type_of(), target: AmlType::Package })
         }
     }
 
@@ -174,7 +178,7 @@ impl PciRoutingTable {
                 let resources = resource::resource_descriptor_list(link_crs)?;
                 match resources.as_slice() {
                     [Resource::Irq(descriptor)] => Ok(descriptor.clone()),
-                    _ => Err(AmlError::IncompatibleValueConversion),
+                    _ => Err(AmlError::IncompatibleValueConversion { current: todo!(), target: todo!() }),
                 }
             }
         }

--- a/aml/src/pci_routing.rs
+++ b/aml/src/pci_routing.rs
@@ -178,7 +178,7 @@ impl PciRoutingTable {
                 let resources = resource::resource_descriptor_list(link_crs)?;
                 match resources.as_slice() {
                     [Resource::Irq(descriptor)] => Ok(descriptor.clone()),
-                    _ => Err(AmlError::IncompatibleValueConversion { current: todo!(), target: todo!() }),
+                    _ => Err(AmlError::UnexpectedResourceType),
                 }
             }
         }

--- a/aml/src/resource.rs
+++ b/aml/src/resource.rs
@@ -1,6 +1,9 @@
 use core::mem;
 
-use crate::{value::AmlValue, AmlError};
+use crate::{
+    value::{AmlType, AmlValue},
+    AmlError,
+};
 use alloc::vec::Vec;
 use bit_field::BitField;
 use byteorder::{ByteOrder, LittleEndian};
@@ -34,7 +37,7 @@ pub fn resource_descriptor_list(descriptor: &AmlValue) -> Result<Vec<Resource>, 
 
         Ok(descriptors)
     } else {
-        Err(AmlError::IncompatibleValueConversion)
+        Err(AmlError::IncompatibleValueConversion { current: descriptor.type_of(), target: AmlType::Buffer })
     }
 }
 

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -243,7 +243,7 @@ impl AmlValue {
         match self {
             AmlValue::Boolean(value) => Ok(*value),
             AmlValue::Integer(value) => Ok(*value != 0),
-            _ => Err(AmlError::IncompatibleValueConversion),
+            _ => Err(AmlError::IncompatibleValueConversion { current: self.type_of(), target: AmlType::Integer }),
         }
     }
 
@@ -274,7 +274,7 @@ impl AmlValue {
              */
             AmlValue::Field { .. } => self.read_field(context)?.as_integer(context),
 
-            _ => Err(AmlError::IncompatibleValueConversion),
+            _ => Err(AmlError::IncompatibleValueConversion { current: self.type_of(), target: AmlType::Integer }),
         }
     }
 
@@ -283,7 +283,7 @@ impl AmlValue {
             AmlValue::Buffer(ref bytes) => Ok(bytes.clone()),
             // TODO: implement conversion of String and Integer to Buffer
             AmlValue::Field { .. } => self.read_field(context)?.as_buffer(context),
-            _ => Err(AmlError::IncompatibleValueConversion),
+            _ => Err(AmlError::IncompatibleValueConversion { current: self.type_of(), target: AmlType::Buffer }),
         }
     }
 
@@ -292,7 +292,7 @@ impl AmlValue {
             AmlValue::String(ref string) => Ok(string.clone()),
             // TODO: implement conversion of Buffer to String
             AmlValue::Field { .. } => self.read_field(context)?.as_string(context),
-            _ => Err(AmlError::IncompatibleValueConversion),
+            _ => Err(AmlError::IncompatibleValueConversion { current: self.type_of(), target: AmlType::String }),
         }
     }
 
@@ -345,7 +345,7 @@ impl AmlValue {
             AmlType::FieldUnit => panic!(
                 "Can't implicitly convert to FieldUnit. This must be special-cased by the caller for now :("
             ),
-            _ => Err(AmlError::IncompatibleValueConversion),
+            _ => Err(AmlError::IncompatibleValueConversion { current: self.type_of(), target: desired_type }),
         }
     }
 
@@ -389,7 +389,7 @@ impl AmlValue {
                 context.read_region(*region, *offset, access_size)?.get_bits(0..(*length as usize)),
             ))
         } else {
-            Err(AmlError::IncompatibleValueConversion)
+            Err(AmlError::IncompatibleValueConversion { current: self.type_of(), target: AmlType::FieldUnit })
         }
     }
 
@@ -402,7 +402,7 @@ impl AmlValue {
         let field_update_rule = if let AmlValue::Field { region, flags, offset, length } = self {
             flags.field_update_rule()?
         } else {
-            return Err(AmlError::IncompatibleValueConversion);
+            return Err(AmlError::IncompatibleValueConversion { current: self.type_of(), target: todo!() });
         };
         let mut field_value = match field_update_rule {
             FieldUpdateRule::Preserve => self.read_field(context)?.as_integer(context)?,
@@ -440,7 +440,7 @@ impl AmlValue {
             field_value.set_bits(0..(*length as usize), value.as_integer(context)?);
             context.write_region(*region, *offset, access_size, field_value)
         } else {
-            Err(AmlError::IncompatibleValueConversion)
+            Err(AmlError::IncompatibleValueConversion { current: self.type_of(), target: AmlType::FieldUnit })
         }
     }
 
@@ -525,7 +525,7 @@ mod tests {
 
         assert_eq!(
             AmlValue::Integer(4).cmp(AmlValue::Boolean(true), &mut context),
-            Err(AmlError::IncompatibleValueConversion)
+            Err(AmlError::IncompatibleValueConversion { current: AmlType::Integer, target: AmlType::Integer })
         );
 
         // TODO: test the other combinations too, as well as conversions to the correct types for the second operand

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -402,7 +402,10 @@ impl AmlValue {
         let field_update_rule = if let AmlValue::Field { region, flags, offset, length } = self {
             flags.field_update_rule()?
         } else {
-            return Err(AmlError::IncompatibleValueConversion { current: self.type_of(), target: todo!() });
+            return Err(AmlError::IncompatibleValueConversion {
+                current: self.type_of(),
+                target: AmlType::FieldUnit,
+            });
         };
         let mut field_value = match field_update_rule {
             FieldUpdateRule::Preserve => self.read_field(context)?.as_integer(context)?,


### PR DESCRIPTION
In a few places I wasn't able to figure out what the appropriate types to return in the error are, so I put `todo!()` instead of those values.

In a few other places I looked at what `AmlType` the `AmlValue` gets turned into here:
https://github.com/rust-osdev/acpi/blob/2fef29cb187dc944550b86ae978ae1620d7249e8/aml/src/value.rs#L227-L240

This made me wonder whether an `impl From<&AmlValue> for AmlType` would make sense. That would ensure that the conversion logic is in one place, instead of in multiple.