### PR TITLE
Regression: Ensure `AmlContext` is `Send` and `Sync` again.

### DIFF
--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -673,7 +673,7 @@ impl AmlContext {
 }
 
 // TODO: docs
-pub trait Handler {
+pub trait Handler: Send + Sync {
     fn read_u8(&self, address: usize) -> u8;
     fn read_u16(&self, address: usize) -> u16;
     fn read_u32(&self, address: usize) -> u32;


### PR DESCRIPTION
Before the introduction of native methods, the `AmlContext` structure was both `Send` and `Sync`, allowing it to be stored inside containers that require this.

For example, I store it in `spin::Once` to allow the global structure to be initialized once and shared, avoiding both complex data flow (e.g. across kernel tasks) and reparsing the AML many times.

To do this I made three changes:

1. The `Fn` for native methods in `MethodCode::Native` is now required to
be `Send` and `Sync`.
2. It now wraps the native function in an `alloc::sync::Arc` instead of `alloc::rc::Rc`.
3. The `Handler` trait requires implementations to implement `Send` and `Sync`.