### PR TITLE
Add test to verify that AmlContext implements Send and Sync

### DIFF
--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -791,3 +791,15 @@ pub enum AmlError {
     FieldInvalidAccessSize,
     TypeCannotBeCompared(AmlType),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_send_sync() {
+        // verify that AmlContext implements Send and Sync
+        fn test_send_sync<T: Send + Sync>() {}
+        test_send_sync::<AmlContext>();
+    }
+}


### PR DESCRIPTION
This pr adds a simple test to verify that `AmlContext` implements `Send + Sync`.

Closes #98