### PR TITLE
implement Send + Sync for PhysicalMapping

### DIFF
--- a/rsdp/src/handler.rs
+++ b/rsdp/src/handler.rs
@@ -14,6 +14,9 @@ where
     pub handler: H,
 }
 
+unsafe impl<H: AcpiHandler + Send, T: Send> Send for PhysicalMapping<H, T> {}
+unsafe impl<H: AcpiHandler + Sync, T: Sync> Sync for PhysicalMapping<H, T> {}
+
 impl<H, T> Deref for PhysicalMapping<H, T>
 where
     H: AcpiHandler,
@@ -48,4 +51,18 @@ pub trait AcpiHandler: Clone + Sized {
 
     /// Unmap the given physical mapping. This is called when a `PhysicalMapping` is dropped.
     fn unmap_physical_region<T>(&self, region: &PhysicalMapping<Self, T>);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_send_sync() {
+        // verify that PhysicalMapping implements Send and Sync
+        fn test_send_sync<T: Send + Sync>() {}
+        fn caller<H: AcpiHandler + Send + Sync, T: Send + Sync>() {
+            test_send_sync::<PhysicalMapping<H, T>>();
+        }
+    }
 }

--- a/rsdp/src/handler.rs
+++ b/rsdp/src/handler.rs
@@ -15,7 +15,6 @@ where
 }
 
 unsafe impl<H: AcpiHandler + Send, T: Send> Send for PhysicalMapping<H, T> {}
-unsafe impl<H: AcpiHandler + Sync, T: Sync> Sync for PhysicalMapping<H, T> {}
 
 impl<H, T> Deref for PhysicalMapping<H, T>
 where
@@ -60,8 +59,8 @@ mod tests {
     #[test]
     fn test_send_sync() {
         // verify that PhysicalMapping implements Send and Sync
-        fn test_send_sync<T: Send + Sync>() {}
-        fn caller<H: AcpiHandler + Send + Sync, T: Send + Sync>() {
+        fn test_send_sync<T: Send>() {}
+        fn caller<H: AcpiHandler + Send, T: Send>() {
             test_send_sync::<PhysicalMapping<H, T>>();
         }
     }

--- a/rsdp/src/lib.rs
+++ b/rsdp/src/lib.rs
@@ -10,6 +10,9 @@
 #![feature(unsafe_block_in_unsafe_fn)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
+#[cfg(test)]
+extern crate std;
+
 pub mod handler;
 
 use core::{mem, ops::Range, slice, str};


### PR DESCRIPTION
This pr implements `Send + Sync` for `PhysicalMapping` and add a test to check for those implementations.