### PR TITLE
Fix physical mapping soundness

### DIFF
--- a/acpi/Cargo.toml
+++ b/acpi/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 bit_field = "0.10"
-rsdp = "1"
+rsdp = { version = "1", path = "../rsdp" }

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -163,7 +163,7 @@ where
 
             let num_tables = (mapping.length as usize - mem::size_of::<SdtHeader>()) / mem::size_of::<u32>();
             let tables_base =
-                ((mapping.virtual_start.as_ptr() as usize) + mem::size_of::<SdtHeader>()) as *const u32;
+                ((mapping.virtual_start().as_ptr() as usize) + mem::size_of::<SdtHeader>()) as *const u32;
 
             for i in 0..num_tables {
                 result.process_sdt(unsafe { *tables_base.offset(i as isize) as usize })?;
@@ -176,7 +176,7 @@ where
 
             let num_tables = (mapping.length as usize - mem::size_of::<SdtHeader>()) / mem::size_of::<u64>();
             let tables_base =
-                ((mapping.virtual_start.as_ptr() as usize) + mem::size_of::<SdtHeader>()) as *const u64;
+                ((mapping.virtual_start().as_ptr() as usize) + mem::size_of::<SdtHeader>()) as *const u64;
 
             for i in 0..num_tables {
                 result.process_sdt(unsafe { *tables_base.offset(i as isize) as usize })?;

--- a/rsdp/src/handler.rs
+++ b/rsdp/src/handler.rs
@@ -92,8 +92,8 @@ pub trait AcpiHandler: Clone {
     ///
     /// ## Safety
     ///
-    /// `physical_address` must point to a valid `T` in physical memory.
-    /// `size` must be at least `size_of::<T>()`.
+    /// - `physical_address` must point to a valid `T` in physical memory.
+    /// - `size` must be at least `size_of::<T>()`.
     unsafe fn map_physical_region<T>(&self, physical_address: usize, size: usize) -> PhysicalMapping<Self, T>;
 
     /// Unmap the given physical mapping. This is called when a `PhysicalMapping` is dropped.

--- a/rsdp/src/handler.rs
+++ b/rsdp/src/handler.rs
@@ -84,7 +84,7 @@ where
 /// however you please, as long as they conform to the documentation of each function. The handler is stored in
 /// every `PhysicalMapping` so it's able to unmap itself when dropped, so this type needs to be something you can
 /// clone/move about freely (e.g. a reference, wrapper over `Rc`, marker struct, etc.).
-pub trait AcpiHandler: Clone + Sized {
+pub trait AcpiHandler: Clone {
     /// Given a physical address and a size, map a region of physical memory that contains `T` (note: the passed
     /// size may be larger than `size_of::<T>()`). The address is not neccessarily page-aligned, so the
     /// implementation may need to map more than `size` bytes. The virtual address the region is mapped to does not

--- a/rsdp/src/handler.rs
+++ b/rsdp/src/handler.rs
@@ -23,7 +23,7 @@ where
     ///
     /// ## Safety
     ///
-    /// This function must only be called by the `AcpiHandler` `H` to make sure that it's safe to unmap the mapping.
+    /// This function must only be called by an `AcpiHandler` of type `H` to make sure that it's safe to unmap the mapping.
     ///
     /// - `virtual_start` must be a valid pointer.
     /// - `region_length` must be equal to or larger than `size_of::<T>()`.
@@ -96,6 +96,8 @@ pub trait AcpiHandler: Clone {
     /// - `size` must be at least `size_of::<T>()`.
     unsafe fn map_physical_region<T>(&self, physical_address: usize, size: usize) -> PhysicalMapping<Self, T>;
 
-    /// Unmap the given physical mapping. This is called when a `PhysicalMapping` is dropped.
+    /// Unmap the given physical mapping. This is called when a `PhysicalMapping` is dropped, you should **not** manually call this.
+    ///
+    /// Note: A reference to the handler used to construct `region` can be acquired by calling [`PhysicalMapping::handler`].
     fn unmap_physical_region<T>(region: &PhysicalMapping<Self, T>);
 }

--- a/rsdp/src/lib.rs
+++ b/rsdp/src/lib.rs
@@ -83,7 +83,7 @@ impl Rsdp {
 
                 for address in area.clone().step_by(16) {
                     let ptr_in_mapping =
-                        unsafe { mapping.virtual_start.as_ptr().offset((address - area.start) as isize) };
+                        unsafe { mapping.virtual_start().as_ptr().offset((address - area.start) as isize) };
                     let signature = unsafe { *(ptr_in_mapping as *const [u8; 8]) };
 
                     if signature == *RSDP_SIGNATURE {


### PR DESCRIPTION
This pr makes `PhysicalMapping` sound:
- Previously one could safely construct a `PhysicalMapping` with `virtual_start` set to an invalid pointer and dereference it. This pr adds `PhysicalMapping::new` which is unsafe.
- `AcpiHandler::unmap_physical_region` no longer takes `self`. Implementations should use `PhysicalMapping::handler` to get the correct mapper. While it wasn't necessarily unsound to call `unmap_physical_region` on another `PhysicalMapper` removing `self` makes it's easier to implement `unmap_physical_region` safely.

This is a __breaking__ change.