### PR TITLE
Add fixed flags and boot architecture flags; add extra table signatures as specified in tables 5.5 and 5.6 of ACPI 6.4

### DIFF
--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -167,7 +167,7 @@ impl Fadt {
     pub fn pm1a_event_block(&self) -> Result<GenericAddress, AcpiError> {
         if let Some(raw) = unsafe { self.x_pm1a_event_block.access(self.header().revision) } {
             if raw.address != 0x0 {
-                return Ok(GenericAddress::from_raw(raw)?);
+                return GenericAddress::from_raw(raw);
             }
         }
 
@@ -203,7 +203,7 @@ impl Fadt {
     pub fn pm1a_control_block(&self) -> Result<GenericAddress, AcpiError> {
         if let Some(raw) = unsafe { self.x_pm1a_control_block.access(self.header().revision) } {
             if raw.address != 0x0 {
-                return Ok(GenericAddress::from_raw(raw)?);
+                return GenericAddress::from_raw(raw);
             }
         }
 
@@ -507,3 +507,4 @@ impl ArmBootArchFlags {
         self.0.get_bit(1)
     }
 }
+

--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -348,7 +348,7 @@ impl FixedFeatureFlags {
         self.0.get_bit(0)
     }
 
-    /// If true, [WBINVD](https://www.felixcloutier.com/x86/wbinvd) properly flushes all caches, but memory coherency is not maintained.
+    /// If true, [WBINVD](https://www.felixcloutier.com/x86/wbinvd) properly flushes all caches and  memory coherency is maintained, but caches may not be invalidated.
     pub fn wbinvd_flushes_all_caches(&self) -> bool {
         self.0.get_bit(1)
     }
@@ -375,8 +375,8 @@ impl FixedFeatureFlags {
         self.0.get_bit(5)
     }
 
-    /// If true, the RTC wake status is supported in fixed register space.
-    pub fn rtc_wake_in_fixed_register_space(&self) -> bool {
+    /// If true, the RTC wake status is not supported in fixed register space.
+    pub fn no_rtc_wake_in_fixed_register_space(&self) -> bool {
         self.0.get_bit(6)
     }
 
@@ -386,6 +386,7 @@ impl FixedFeatureFlags {
     }
 
     /// If true, indicates that the PM timer is a 32-bit value.
+    /// If false, the PM timer is a 24-bit value and the remaining 8 bits are clear.
     pub fn pm_timer_is_32_bit(&self) -> bool {
         self.0.get_bit(8)
     }
@@ -465,28 +466,28 @@ impl IaPcBootArchFlags {
         self.0.get_bit(0)
     }
 
-    /// If true, the motherboard exposes an IO port 60/64 keyboard controller, typically implemented as an 8064 microcontroller.
+    /// If true, the motherboard exposes an IO port 60/64 keyboard controller, typically implemented as an 8042 microcontroller.
     pub fn motherboard_implements_8042(&self) -> bool {
         self.0.get_bit(1)
     }
 
-    /// If true, OSPM must not blindly probe VGA hardware.
+    /// If true, OSPM *must not* blindly probe VGA hardware.
     /// VGA hardware is at MMIO addresses A0000h-BFFFFh and IO ports 3B0h-3BBh and 3C0h-3DFh.
     pub fn dont_probe_vga(&self) -> bool {
         self.0.get_bit(2)
     }
 
-    /// If true, OSPM must not enable message-signaled interrupts.
+    /// If true, OSPM *must not* enable message-signaled interrupts.
     pub fn dont_enable_msi(&self) -> bool {
         self.0.get_bit(3)
     }
 
-    /// If true, OSPM must not enable PCIe ASPM control.
+    /// If true, OSPM *must not* enable PCIe ASPM control.
     pub fn dont_enable_pcie_aspm(&self) -> bool {
         self.0.get_bit(4)
     }
 
-    /// If true, OSPM must not use the RTC via its IO ports either because it isn't implemented or is at other addresses;
+    /// If true, OSPM *must not* use the RTC via its IO ports, either because it isn't implemented or is at other addresses;
     /// instead, OSPM *MUST* use the time and alarm namespace device control method.
     pub fn use_time_and_alarm_namespace_for_rtc(&self) -> bool {
         self.0.get_bit(5)

--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -92,14 +92,12 @@ pub struct Fadt {
     pub day_alarm: u8,
     pub month_alarm: u8,
     pub century: u8,
-    // TODO: expose through a type
-    iapc_boot_arch: u16,
+    pub iapc_boot_arch: IaPcBootArchFlags,
     _reserved2: u8, // must be 0
-    pub flags: Flags,
+    pub flags: FixedFeatureFlags,
     reset_reg: RawGenericAddress,
     pub reset_value: u8,
-    // TODO: expose through a type
-    arm_boot_arch: u16,
+    pub arm_boot_arch: ArmBootArchFlags,
     fadt_minor_version: u8,
     x_firmware_ctrl: ExtendedField<u64, 2>,
     x_dsdt_address: ExtendedField<u64, 2>,
@@ -340,11 +338,172 @@ impl Fadt {
 }
 
 #[derive(Clone, Copy)]
-// TODO: methods for other flags
-pub struct Flags(u32);
+pub struct FixedFeatureFlags(u32);
 
-impl Flags {
+impl FixedFeatureFlags {
+    /// If true, an equivalent to the x86 [WBINVD](https://www.felixcloutier.com/x86/wbinvd) instruction is supported.
+    /// All caches will be flushed and invalidated upon completion of this instruction,
+    /// and memory coherency is properly maintained. The cache *SHALL* only contain what OSPM references or allows to be cached.
+    pub fn supports_equivalent_to_wbinvd(&self) -> bool {
+        self.0.get_bit(0)
+    }
+
+    /// If true, [WBINVD](https://www.felixcloutier.com/x86/wbinvd) properly flushes all caches, but memory coherency is not maintained.
+    pub fn wbinvd_flushes_all_caches(&self) -> bool {
+        self.0.get_bit(1)
+    }
+
+    /// If true, all processors implement the C1 power state.
+    pub fn all_procs_support_c1_power_state(&self) -> bool {
+        self.0.get_bit(2)
+    }
+
+    /// If true, the C2 power state is configured to work on a uniprocessor and multiprocessor system.
+    pub fn c2_configured_for_mp_system(&self) -> bool {
+        self.0.get_bit(3)
+    }
+
+    /// If true, the power button is handled as a control method device.
+    /// If false, the power button is handled as a fixed-feature programming model.
+    pub fn power_button_is_control_method(&self) -> bool {
+        self.0.get_bit(4)
+    }
+
+    /// If true, the sleep button is handled as a control method device.
+    /// If false, the sleep button is handled as a fixed-feature programming model.
+    pub fn sleep_button_is_control_method(&self) -> bool {
+        self.0.get_bit(5)
+    }
+
+    /// If true, the RTC wake status is supported in fixed register space.
+    pub fn rtc_wake_in_fixed_register_space(&self) -> bool {
+        self.0.get_bit(6)
+    }
+
+    /// If true, the RTC alarm function can wake the system from an S4 sleep state.
+    pub fn rtc_wakes_system_from_s4(&self) -> bool {
+        self.0.get_bit(7)
+    }
+
+    /// If true, indicates that the PM timer is a 32-bit value.
     pub fn pm_timer_is_32_bit(&self) -> bool {
         self.0.get_bit(8)
+    }
+
+    /// If true, the system supports docking.
+    pub fn supports_docking(&self) -> bool {
+        self.0.get_bit(9)
+    }
+
+    /// If true, the system supports system reset via the reset_reg field of the FADT.
+    pub fn supports_system_reset_via_fadt(&self) -> bool {
+        self.0.get_bit(10)
+    }
+
+    /// If true, the system supports no expansion capabilities and the case is sealed.
+    pub fn case_is_sealed(&self) -> bool {
+        self.0.get_bit(11)
+    }
+
+    /// If true, the system cannot detect the monitor or keyboard/mouse devices.
+    pub fn system_is_headless(&self) -> bool {
+        self.0.get_bit(12)
+    }
+
+    /// If true, OSPM must use a processor instruction after writing to the SLP_TYPx register.
+    pub fn use_instr_after_write_to_slp_typx(&self) -> bool {
+        self.0.get_bit(13)
+    }
+
+    /// If set, the platform supports the `PCIEXP_WAKE_STS` and `PCIEXP_WAKE_EN` bits in the PM1 status and enable registers.
+    pub fn supports_pciexp_wake_in_pm1(&self) -> bool {
+        self.0.get_bit(14)
+    }
+
+    /// If true, OSPM should use the ACPI power management timer or HPET for monotonically-decreasing timers.
+    pub fn use_pm_or_hpet_for_monotonically_decreasing_timers(&self) -> bool {
+        self.0.get_bit(15)
+    }
+
+    /// If true, the contents of the `RTC_STS` register are valid after wakeup from S4.
+    pub fn rtc_sts_is_valid_after_wakeup_from_s4(&self) -> bool {
+        self.0.get_bit(16)
+    }
+
+    /// If true, the platform supports OSPM leaving GPE wake events armed prior to an S5 transition.
+    pub fn ospm_may_leave_gpe_wake_events_armed_before_s5(&self) -> bool {
+        self.0.get_bit(17)
+    }
+
+    /// If true, all LAPICs must be configured using the cluster destination model when delivering interrupts in logical mode.
+    pub fn lapics_must_use_cluster_model_for_logical_mode(&self) -> bool {
+        self.0.get_bit(18)
+    }
+
+    /// If true, all LXAPICs must be configured using physical destination mode.
+    pub fn local_xapics_must_use_physical_destination_mode(&self) -> bool {
+        self.0.get_bit(19)
+    }
+
+    /// If true, this system is a hardware-reduced ACPI platform, and software methods are used for fixed-feature functions defined in chapter 4 of the ACPI specification.
+    pub fn system_is_hw_reduced_acpi(&self) -> bool {
+        self.0.get_bit(20)
+    }
+
+    /// If true, the system can achieve equal or better power savings in an S0 power state, making an S3 transition useless.
+    pub fn no_benefit_to_s3(&self) -> bool {
+        self.0.get_bit(21)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct IaPcBootArchFlags(u16);
+
+impl IaPcBootArchFlags {
+    /// If true, legacy user-accessible devices are available on the LPC and/or ISA buses.
+    pub fn legacy_devices_are_accessible(&self) -> bool {
+        self.0.get_bit(0)
+    }
+
+    /// If true, the motherboard exposes an IO port 60/64 keyboard controller, typically implemented as an 8064 microcontroller.
+    pub fn motherboard_implements_8042(&self) -> bool {
+        self.0.get_bit(1)
+    }
+
+    /// If true, OSPM must not blindly probe VGA hardware.
+    /// VGA hardware is at MMIO addresses A0000h-BFFFFh and IO ports 3B0h-3BBh and 3C0h-3DFh.
+    pub fn dont_probe_vga(&self) -> bool {
+        self.0.get_bit(2)
+    }
+
+    /// If true, OSPM must not enable message-signaled interrupts.
+    pub fn dont_enable_msi(&self) -> bool {
+        self.0.get_bit(3)
+    }
+
+    /// If true, OSPM must not enable PCIe ASPM control.
+    pub fn dont_enable_pcie_aspm(&self) -> bool {
+        self.0.get_bit(4)
+    }
+
+    /// If true, OSPM must not use the RTC via its IO ports either because it isn't implemented or is at other addresses;
+    /// instead, OSPM *MUST* use the time and alarm namespace device control method.
+    pub fn use_time_and_alarm_namespace_for_rtc(&self) -> bool {
+        self.0.get_bit(5)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ArmBootArchFlags(u16);
+
+impl ArmBootArchFlags {
+    /// If true, the system implements PSCI.
+    pub fn implements_psci(&self) -> bool {
+        self.0.get_bit(0)
+    }
+
+    /// If true, OSPM must use HVC instead of SMC as the PSCI conduit.
+    pub fn use_hvc_as_psci_conduit(&self) -> bool {
+        self.0.get_bit(1)
     }
 }

--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -125,7 +125,7 @@ impl Madt {
 
         for entry in self.entries() {
             match entry {
-                MadtEntry::LocalApic(ref entry) => {
+                MadtEntry::LocalApic(entry) => {
                     /*
                      * The first processor is the BSP. Subsequent ones are APs. If we haven't found
                      * the BSP yet, this must be it.
@@ -153,7 +153,7 @@ impl Madt {
                     }
                 }
 
-                MadtEntry::IoApic(ref entry) => {
+                MadtEntry::IoApic(entry) => {
                     io_apics.push(IoApic {
                         id: entry.io_apic_id,
                         address: entry.io_apic_address,
@@ -161,7 +161,7 @@ impl Madt {
                     });
                 }
 
-                MadtEntry::InterruptSourceOverride(ref entry) => {
+                MadtEntry::InterruptSourceOverride(entry) => {
                     if entry.bus != 0 {
                         return Err(AcpiError::InvalidMadt(MadtError::InterruptOverrideEntryHasInvalidBus));
                     }
@@ -176,7 +176,7 @@ impl Madt {
                     });
                 }
 
-                MadtEntry::NmiSource(ref entry) => {
+                MadtEntry::NmiSource(entry) => {
                     let (polarity, trigger_mode) = parse_mps_inti_flags(entry.flags)?;
 
                     nmi_sources.push(NmiSource {
@@ -186,7 +186,7 @@ impl Madt {
                     });
                 }
 
-                MadtEntry::LocalApicNmi(ref entry) => local_apic_nmi_lines.push(NmiLine {
+                MadtEntry::LocalApicNmi(entry) => local_apic_nmi_lines.push(NmiLine {
                     processor: if entry.processor_id == 0xff {
                         NmiProcessor::All
                     } else {
@@ -199,7 +199,7 @@ impl Madt {
                     },
                 }),
 
-                MadtEntry::LocalApicAddressOverride(ref entry) => {
+                MadtEntry::LocalApicAddressOverride(entry) => {
                     local_apic_address = entry.local_apic_address;
                 }
 
@@ -224,7 +224,7 @@ impl Madt {
 
     pub fn entries(&self) -> MadtEntryIter {
         MadtEntryIter {
-            pointer: unsafe { (self as *const Madt as *const u8).offset(mem::size_of::<Madt>() as isize) },
+            pointer: unsafe { (self as *const Madt as *const u8).add(mem::size_of::<Madt>()) },
             remaining_length: self.header.length - mem::size_of::<Madt>() as u32,
             _phantom: PhantomData,
         }

--- a/acpi/src/mcfg.rs
+++ b/acpi/src/mcfg.rs
@@ -22,7 +22,7 @@ impl PciConfigRegions {
                 .get_sdt::<Mcfg>(crate::sdt::Signature::MCFG)?
                 .ok_or(AcpiError::TableMissing(crate::sdt::Signature::MCFG))?
         };
-        Ok(PciConfigRegions { regions: mcfg.entries().iter().map(|&entry| entry).collect() })
+        Ok(PciConfigRegions { regions: mcfg.entries().iter().copied().collect() })
     }
 
     /// Get the physical address of the start of the configuration space for a given PCIe device
@@ -67,8 +67,7 @@ impl Mcfg {
         let num_entries = length / mem::size_of::<McfgEntry>();
 
         unsafe {
-            let pointer =
-                (self as *const Mcfg as *const u8).offset(mem::size_of::<Mcfg>() as isize) as *const McfgEntry;
+            let pointer = (self as *const Mcfg as *const u8).add(mem::size_of::<Mcfg>()) as *const McfgEntry;
             slice::from_raw_parts(pointer, num_entries)
         }
     }

--- a/acpi/src/platform/mod.rs
+++ b/acpi/src/platform/mod.rs
@@ -1,7 +1,14 @@
 pub mod address;
 pub mod interrupt;
 
-use crate::{fadt::Fadt, madt::Madt, AcpiError, AcpiHandler, AcpiTables, PowerProfile};
+use crate::{
+    fadt::Fadt,
+    madt::Madt,
+    AcpiError,
+    AcpiHandler,
+    AcpiTables,
+    PowerProfile,
+};
 use address::GenericAddress;
 use alloc::vec::Vec;
 use interrupt::InterruptModel;
@@ -51,7 +58,10 @@ pub struct PmTimer {
 impl PmTimer {
     pub fn new(fadt: &Fadt) -> Result<Option<PmTimer>, AcpiError> {
         match fadt.pm_timer_block()? {
-            Some(base) => Ok(Some(PmTimer { base, supports_32bit: { fadt.flags }.pm_timer_is_32_bit() })),
+            Some(base) => Ok(Some(PmTimer {
+                base,
+                supports_32bit: {fadt.flags}.pm_timer_is_32_bit(),
+            })),
             None => Ok(None),
         }
     }

--- a/acpi/src/sdt.rs
+++ b/acpi/src/sdt.rs
@@ -23,39 +23,77 @@ impl<T: Copy, const MIN_REVISION: u8> ExtendedField<T, MIN_REVISION> {
 /// All SDTs share the same header, and are `length` bytes long. The signature tells us which SDT
 /// this is.
 ///
-/// The ACPI Spec (Version 6.2) defines the following SDT signatures:
-///     "APIC" - Multiple APIC Descriptor Table (MADT)
-///     "BGRT" - Boot Graphics Resource Table
-///     "BERT" - Boot Error Record Table
-///     "CPEP" - Corrected Platform Error Polling Table
-///     "DSDT" - Differentiated System Descriptor Table
-///     "ECDT" - Embedded Controller Boot Resources Table
-///     "EINJ" - Error Injection Table
-///     "ERST" - Error Record Serialization Table
-///     "FACP" - Fixed ACPI Description Table (FADT)
-///     "FACS" - Firmware ACPI Control Structure
-///     "FPDT" - Firmware Performance Data Table
-///     "GTDT" - Generic Timer Description Table
-///     "HEST" - Hardware Error Source Table
-///     "HMAT" - Heterogeneous Memory Attributes Table
-///     "MSCT" - Maximum System Characteristics Table
-///     "MPST" - Memory Power State Table
-///     "NFIT" - NVDIMM Firmware Interface Table
-///     "OEMx" - Various OEM-specific tables
-///     "PDTT" - Platform Debug Trigger Table
-///     "PMTT" - Platform Memory Topology Table
-///     "PPTT" - Processor Properties Topology Table
-///     "PSDT" - Persistent System Description Table
-///     "RASF" - ACPI RAS Feature Table
-///     "RSDT" - Root System Descriptor Table
-///     "SBST" - Smart Battery Specification Table
-///     "SLIT" - System Locality Information Table
-///     "SRAT" - System Resource Affinity Table
-///     "SSDT" - Secondary System Description Table
-///     "XSDT" - eXtended System Descriptor Table
+/// The ACPI Spec (Version 6.4) defines the following SDT signatures:
 ///
-/// We've come across some more ACPI tables in the wild:
-///     "WAET" - Windows ACPI Emulated device Table
+/// * APIC - Multiple APIC Description Table (MADT)
+/// *BERT - Boot Error Record Table
+/// *BGRT - Boot Graphics Resource Table
+/// *CPEP - Corrected Platform Error Polling Table
+/// *DSDT - Differentiated System Description Table (DSDT)
+/// *ECDT - Embedded Controller Boot Resources Table
+/// *EINJ - Error Injection Table
+/// *ERST - Error Record Serialization Table
+/// *FACP - Fixed ACPI Description Table (FADT)
+/// *FACS - Firmware ACPI Control Structure
+/// *FPDT - Firmware Performance Data Table
+/// *GTDT - Generic Timer Description Table
+/// *HEST - Hardware Error Source Table
+/// *MSCT - Maximum System Characteristics Table
+/// *MPST - Memory Power StateTable
+/// *NFIT - NVDIMM Firmware Interface Table
+/// *OEMx - OEM Specific Information Tables
+/// *PCCT - Platform Communications Channel Table
+/// *PHAT - Platform Health Assessment Table
+/// *PMTT - Platform Memory Topology Table
+/// *PSDT - Persistent System Description Table
+/// *RASF - ACPI RAS Feature Table
+/// *RSDT - Root System Description Table
+/// *SBST - Smart Battery Specification Table
+/// *SDEV - Secure DEVices Table
+/// *SLIT - System Locality Distance Information Table
+/// *SRAT - System Resource Affinity Table
+/// *SSDT - Secondary System Description Table
+/// *XSDT - Extended System Description Table
+///
+/// Acpi reserves the following signatures and the specifications for them can be found [here](https://uefi.org/acpi):
+///
+/// *AEST - ARM Error Source Table
+/// *BDAT - BIOS Data ACPI Table
+/// *CDIT - Component Distance Information Table
+/// *CEDT - CXL Early Discovery Table
+/// *CRAT - Component Resource Attribute Table
+/// *CSRT - Core System Resource Table
+/// *DBGP - Debug Port Table
+/// *DBG2 - Debug Port Table 2 (note: ACPI 6.4 defines this as "DBPG2" but this is incorrect)
+/// *DMAR - DMA Remapping Table
+/// *DRTM -Dynamic Root of Trust for Measurement Table
+/// *ETDT - Event Timer Description Table (obsolete, superseeded by HPET)
+/// *HPET - IA-PC High Precision Event Timer Table
+/// *IBFT - iSCSI Boot Firmware Table
+/// *IORT - I/O Remapping Table
+/// *IVRS - I/O Virtualization Reporting Structure
+/// *LPIT - Low Power Idle Table
+/// *MCFG - PCI Express Memory-mapped Configuration Space base address description table
+/// *MCHI - Management Controller Host Interface table
+/// *MPAM - ARM Memory Partitioning And Monitoring table
+/// *MSDM - Microsoft Data Management Table
+/// *PRMT - Platform Runtime Mechanism Table
+/// *RGRT - Regulatory Graphics Resource Table
+/// *SDEI - Software Delegated Exceptions Interface table
+/// *SLIC - Microsoft Software Licensing table
+/// *SPCR - Microsoft Serial Port Console Redirection table
+/// *SPMI - Server Platform Management Interface table
+/// *STAO - _STA Override table
+/// *SVKL - Storage Volume Key Data table (Intel TDX only)
+/// *TCPA - Trusted Computing Platform Alliance Capabilities Table
+/// *TPM2 - Trusted Platform Module 2 Table
+/// *UEFI - Unified Extensible Firmware Interface Specification table
+/// *WAET - Windows ACPI Emulated Devices Table
+/// *WDAT - Watch Dog Action Table
+/// *WDRT - Watchdog Resource Table
+/// *WPBT - Windows Platform Binary Table
+/// *WSMT - Windows Security Mitigations Table
+/// *XENV - Xen Project
 #[derive(Clone, Copy)]
 #[repr(C, packed)]
 pub struct SdtHeader {
@@ -73,7 +111,7 @@ pub struct SdtHeader {
 impl SdtHeader {
     /// Check that:
     ///     a) The signature matches the one given
-    ///     b) The checksum of the SDT
+    ///     b) The checksum of the SDT is valid
     ///
     /// This assumes that the whole SDT is mapped.
     pub fn validate(&self, signature: Signature) -> Result<(), AcpiError> {
@@ -129,6 +167,64 @@ impl Signature {
     pub const MADT: Signature = Signature(*b"APIC");
     pub const MCFG: Signature = Signature(*b"MCFG");
     pub const SSDT: Signature = Signature(*b"SSDT");
+    pub const BERT: Signature = Signature(*b"BERT");
+    pub const BGRT: Signature = Signature(*b"BGRT");
+    pub const CPEP: Signature = Signature(*b"CPEP");
+    pub const DSDT: Signature = Signature(*b"DSDT");
+    pub const ECDT: Signature = Signature(*b"ECDT");
+    pub const EINJ: Signature = Signature(*b"EINJ");
+    pub const ERST: Signature = Signature(*b"ERST");
+    pub const FACS: Signature = Signature(*b"FACS");
+    pub const FPDT: Signature = Signature(*b"FPDT");
+    pub const GTDT: Signature = Signature(*b"GTDT");
+    pub const HEST: Signature = Signature(*b"HEST");
+    pub const MSCT: Signature = Signature(*b"MSCT");
+    pub const MPST: Signature = Signature(*b"MPST");
+    pub const NFIT: Signature = Signature(*b"NFIT");
+    pub const PCCT: Signature = Signature(*b"PCCT");
+    pub const PHAT: Signature = Signature(*b"PHAT");
+    pub const PMTT: Signature = Signature(*b"PMTT");
+    pub const PSDT: Signature = Signature(*b"PSDT");
+    pub const RASF: Signature = Signature(*b"RASF");
+    pub const SBST: Signature = Signature(*b"SBST");
+    pub const SDEV: Signature = Signature(*b"SDEV");
+    pub const SLIT: Signature = Signature(*b"SLIT");
+    pub const SRAT: Signature = Signature(*b"SRAT");
+    pub const AEST: Signature = Signature(*b"AEST");
+    pub const BDAT: Signature = Signature(*b"BDAT");
+    pub const CDIT: Signature = Signature(*b"CDIT");
+    pub const CEDT: Signature = Signature(*b"CEDT");
+    pub const CRAT: Signature = Signature(*b"CRAT");
+    pub const CSRT: Signature = Signature(*b"CSRT");
+    pub const DBGP: Signature = Signature(*b"DBGP");
+    pub const DBG2: Signature = Signature(*b"DBG2");
+    pub const DMAR: Signature = Signature(*b"DMAR");
+    pub const DRTM: Signature = Signature(*b"DRTM");
+    pub const ETDT: Signature = Signature(*b"ETDT");
+    pub const IBFT: Signature = Signature(*b"IBFT");
+    pub const IORT: Signature = Signature(*b"IORT");
+    pub const IVRS: Signature = Signature(*b"IVRS");
+    pub const LPIT: Signature = Signature(*b"LPIT");
+    pub const MCHI: Signature = Signature(*b"MCHI");
+    pub const MPAM: Signature = Signature(*b"MPAM");
+    pub const MSDM: Signature = Signature(*b"MSDM");
+    pub const PRMT: Signature = Signature(*b"PRMT");
+    pub const RGRT: Signature = Signature(*b"RGRT");
+    pub const SDEI: Signature = Signature(*b"SDEI");
+    pub const SLIC: Signature = Signature(*b"SLIC");
+    pub const SPCR: Signature = Signature(*b"SPCR");
+    pub const SPMI: Signature = Signature(*b"SPMI");
+    pub const STAO: Signature = Signature(*b"STAO");
+    pub const SVKL: Signature = Signature(*b"SVKL");
+    pub const TCPA: Signature = Signature(*b"TCPA");
+    pub const TPM2: Signature = Signature(*b"TPM2");
+    pub const UEFI: Signature = Signature(*b"UEFI");
+    pub const WAET: Signature = Signature(*b"WAET");
+    pub const WDAT: Signature = Signature(*b"WDAT");
+    pub const WDRT: Signature = Signature(*b"WDRT");
+    pub const WPBT: Signature = Signature(*b"WPBT");
+    pub const WSMT: Signature = Signature(*b"WSMT");
+    pub const XENV: Signature = Signature(*b"XENV");
 
     pub fn as_str(&self) -> &str {
         str::from_utf8(&self.0).unwrap()

--- a/acpi/src/sdt.rs
+++ b/acpi/src/sdt.rs
@@ -26,74 +26,74 @@ impl<T: Copy, const MIN_REVISION: u8> ExtendedField<T, MIN_REVISION> {
 /// The ACPI Spec (Version 6.4) defines the following SDT signatures:
 ///
 /// * APIC - Multiple APIC Description Table (MADT)
-/// *BERT - Boot Error Record Table
-/// *BGRT - Boot Graphics Resource Table
-/// *CPEP - Corrected Platform Error Polling Table
-/// *DSDT - Differentiated System Description Table (DSDT)
-/// *ECDT - Embedded Controller Boot Resources Table
-/// *EINJ - Error Injection Table
-/// *ERST - Error Record Serialization Table
-/// *FACP - Fixed ACPI Description Table (FADT)
-/// *FACS - Firmware ACPI Control Structure
-/// *FPDT - Firmware Performance Data Table
-/// *GTDT - Generic Timer Description Table
-/// *HEST - Hardware Error Source Table
-/// *MSCT - Maximum System Characteristics Table
-/// *MPST - Memory Power StateTable
-/// *NFIT - NVDIMM Firmware Interface Table
-/// *OEMx - OEM Specific Information Tables
-/// *PCCT - Platform Communications Channel Table
-/// *PHAT - Platform Health Assessment Table
-/// *PMTT - Platform Memory Topology Table
-/// *PSDT - Persistent System Description Table
-/// *RASF - ACPI RAS Feature Table
-/// *RSDT - Root System Description Table
-/// *SBST - Smart Battery Specification Table
-/// *SDEV - Secure DEVices Table
-/// *SLIT - System Locality Distance Information Table
-/// *SRAT - System Resource Affinity Table
-/// *SSDT - Secondary System Description Table
-/// *XSDT - Extended System Description Table
+/// * BERT - Boot Error Record Table
+/// * BGRT - Boot Graphics Resource Table
+/// * CPEP - Corrected Platform Error Polling Table
+/// * DSDT - Differentiated System Description Table (DSDT)
+/// * ECDT - Embedded Controller Boot Resources Table
+/// * EINJ - Error Injection Table
+/// * ERST - Error Record Serialization Table
+/// * FACP - Fixed ACPI Description Table (FADT)
+/// * FACS - Firmware ACPI Control Structure
+/// * FPDT - Firmware Performance Data Table
+/// * GTDT - Generic Timer Description Table
+/// * HEST - Hardware Error Source Table
+/// * MSCT - Maximum System Characteristics Table
+/// * MPST - Memory Power StateTable
+/// * NFIT - NVDIMM Firmware Interface Table
+/// * OEMx - OEM Specific Information Tables
+/// * PCCT - Platform Communications Channel Table
+/// * PHAT - Platform Health Assessment Table
+/// * PMTT - Platform Memory Topology Table
+/// * PSDT - Persistent System Description Table
+/// * RASF - ACPI RAS Feature Table
+/// * RSDT - Root System Description Table
+/// * SBST - Smart Battery Specification Table
+/// * SDEV - Secure DEVices Table
+/// * SLIT - System Locality Distance Information Table
+/// * SRAT - System Resource Affinity Table
+/// * SSDT - Secondary System Description Table
+/// * XSDT - Extended System Description Table
 ///
 /// Acpi reserves the following signatures and the specifications for them can be found [here](https://uefi.org/acpi):
 ///
-/// *AEST - ARM Error Source Table
-/// *BDAT - BIOS Data ACPI Table
-/// *CDIT - Component Distance Information Table
-/// *CEDT - CXL Early Discovery Table
-/// *CRAT - Component Resource Attribute Table
-/// *CSRT - Core System Resource Table
-/// *DBGP - Debug Port Table
-/// *DBG2 - Debug Port Table 2 (note: ACPI 6.4 defines this as "DBPG2" but this is incorrect)
-/// *DMAR - DMA Remapping Table
-/// *DRTM -Dynamic Root of Trust for Measurement Table
-/// *ETDT - Event Timer Description Table (obsolete, superseeded by HPET)
-/// *HPET - IA-PC High Precision Event Timer Table
-/// *IBFT - iSCSI Boot Firmware Table
-/// *IORT - I/O Remapping Table
-/// *IVRS - I/O Virtualization Reporting Structure
-/// *LPIT - Low Power Idle Table
-/// *MCFG - PCI Express Memory-mapped Configuration Space base address description table
-/// *MCHI - Management Controller Host Interface table
-/// *MPAM - ARM Memory Partitioning And Monitoring table
-/// *MSDM - Microsoft Data Management Table
-/// *PRMT - Platform Runtime Mechanism Table
-/// *RGRT - Regulatory Graphics Resource Table
-/// *SDEI - Software Delegated Exceptions Interface table
-/// *SLIC - Microsoft Software Licensing table
-/// *SPCR - Microsoft Serial Port Console Redirection table
-/// *SPMI - Server Platform Management Interface table
-/// *STAO - _STA Override table
-/// *SVKL - Storage Volume Key Data table (Intel TDX only)
-/// *TCPA - Trusted Computing Platform Alliance Capabilities Table
-/// *TPM2 - Trusted Platform Module 2 Table
-/// *UEFI - Unified Extensible Firmware Interface Specification table
-/// *WAET - Windows ACPI Emulated Devices Table
-/// *WDAT - Watch Dog Action Table
-/// *WDRT - Watchdog Resource Table
-/// *WPBT - Windows Platform Binary Table
-/// *WSMT - Windows Security Mitigations Table
-/// *XENV - Xen Project
+/// * AEST - ARM Error Source Table
+/// * BDAT - BIOS Data ACPI Table
+/// * CDIT - Component Distance Information Table
+/// * CEDT - CXL Early Discovery Table
+/// * CRAT - Component Resource Attribute Table
+/// * CSRT - Core System Resource Table
+/// * DBGP - Debug Port Table
+/// * DBG2 - Debug Port Table 2 (note: ACPI 6.4 defines this as "DBPG2" but this is incorrect)
+/// * DMAR - DMA Remapping Table
+/// * DRTM -Dynamic Root of Trust for Measurement Table
+/// * ETDT - Event Timer Description Table (obsolete, superseeded by HPET)
+/// * HPET - IA-PC High Precision Event Timer Table
+/// * IBFT - iSCSI Boot Firmware Table
+/// * IORT - I/O Remapping Table
+/// * IVRS - I/O Virtualization Reporting Structure
+/// * LPIT - Low Power Idle Table
+/// * MCFG - PCI Express Memory-mapped Configuration Space base address description table
+/// * MCHI - Management Controller Host Interface table
+/// * MPAM - ARM Memory Partitioning And Monitoring table
+/// * MSDM - Microsoft Data Management Table
+/// * PRMT - Platform Runtime Mechanism Table
+/// * RGRT - Regulatory Graphics Resource Table
+/// * SDEI - Software Delegated Exceptions Interface table
+/// * SLIC - Microsoft Software Licensing table
+/// * SPCR - Microsoft Serial Port Console Redirection table
+/// * SPMI - Server Platform Management Interface table
+/// * STAO - _STA Override table
+/// * SVKL - Storage Volume Key Data table (Intel TDX only)
+/// * TCPA - Trusted Computing Platform Alliance Capabilities Table
+/// * TPM2 - Trusted Platform Module 2 Table
+/// * UEFI - Unified Extensible Firmware Interface Specification table
+/// * WAET - Windows ACPI Emulated Devices Table
+/// * WDAT - Watch Dog Action Table
+/// * WDRT - Watchdog Resource Table
+/// * WPBT - Windows Platform Binary Table
+/// * WSMT - Windows Security Mitigations Table
+/// * XENV - Xen Project
 #[derive(Clone, Copy)]
 #[repr(C, packed)]
 pub struct SdtHeader {
@@ -144,12 +144,12 @@ impl SdtHeader {
         Ok(())
     }
 
-    pub fn oem_id<'a>(&'a self) -> &'a str {
+    pub fn oem_id(&self) -> &str {
         // Safe to unwrap because checked in `validate`
         str::from_utf8(&self.oem_id).unwrap()
     }
 
-    pub fn oem_table_id<'a>(&'a self) -> &'a str {
+    pub fn oem_table_id(&self) -> &str {
         // Safe to unwrap because checked in `validate`
         str::from_utf8(&self.oem_table_id).unwrap()
     }
@@ -251,5 +251,5 @@ where
 {
     let mapping =
         unsafe { handler.map_physical_region::<SdtHeader>(physical_address, mem::size_of::<SdtHeader>()) };
-    (*mapping).clone()
+    *mapping
 }

--- a/rsdp/src/lib.rs
+++ b/rsdp/src/lib.rs
@@ -88,10 +88,10 @@ impl Rsdp {
 
                 for address in area.clone().step_by(16) {
                     let ptr_in_mapping =
-                        unsafe { mapping.virtual_start().as_ptr().offset((address - area.start) as isize) };
+                        unsafe { mapping.virtual_start().as_ptr().add(address - area.start) };
                     let signature = unsafe { *(ptr_in_mapping as *const [u8; 8]) };
 
-                    if signature == *RSDP_SIGNATURE {
+                    if signature == RSDP_SIGNATURE {
                         match unsafe { *(ptr_in_mapping as *const Rsdp) }.validate() {
                             Ok(()) => {
                                 rsdp_address = Some(address);
@@ -123,7 +123,7 @@ impl Rsdp {
         const RSDP_V1_LENGTH: usize = 20;
 
         // Check the signature
-        if &self.signature != RSDP_SIGNATURE {
+        if self.signature != RSDP_SIGNATURE {
             return Err(RsdpError::IncorrectSignature);
         }
 
@@ -213,4 +213,4 @@ const RSDP_BIOS_AREA_START: usize = 0xe0000;
 /// The end of the main BIOS area below 1mb in which to search for the RSDP (Root System Description Pointer)
 const RSDP_BIOS_AREA_END: usize = 0xfffff;
 /// The RSDP (Root System Description Pointer)'s signature, "RSD PTR " (note trailing space)
-const RSDP_SIGNATURE: &'static [u8; 8] = b"RSD PTR ";
+const RSDP_SIGNATURE: [u8; 8] = *b"RSD PTR ";

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,7 @@
 unstable_features = true
 edition = "2018"
 
-merge_imports = true
+imports_granularity='Crate'
 imports_layout = "HorizontalVertical"
 use_field_init_shorthand = true
 use_try_shorthand = true


### PR DESCRIPTION
Bit of a long title, but this has a breaking change (if I need to rebase, I can do that too, wouldn't be the first time :D). In short:

* This switches to using bitflags for flags in the `fadt` module
* This adds boot architecture and fixed feature flags as specified in tables 5.10-5.12 of [chapter 5 of ACPI 6.4](https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html)
* This PR adds all the remaining signatures that are both reserved by ACPI and used by ACPI-defined tables as specified in tables 5.5-5.6 of the same chapter as above

In future I'm also planning to (possibly) define those tables. I also considered, but rejected for now, moving all the tables to a "tables" module for better organization; I've broken enough for this PR. :)

Signed-off-by: Ethin Probst <ethindp@protonmail.com>