### PR TITLE
chore(acpi): remove an unused feature gate

### DIFF
--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -48,7 +48,6 @@
  */
 
 #![no_std]
-#![feature(const_generics)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 extern crate alloc;


### PR DESCRIPTION
To use this crate on stable Rust.