### PR TITLE
Add the boot graphics resource table as specified in SEC. 5.2.22 of the ACPI specification v. 6.4

### DIFF
--- a/acpi/src/bgrt.rs
+++ b/acpi/src/bgrt.rs
@@ -1,6 +1,8 @@
 use crate::{sdt::SdtHeader, AcpiTable};
 use bit_field::BitField;
 
+/// The BGRT table contains information about a boot graphic that was displayed
+/// by firmware.
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
 pub struct Bgrt {
@@ -23,19 +25,21 @@ impl Bgrt {
     pub fn image_type(&self) -> ImageType {
         let img_type = self.image_type;
         match img_type {
-            1 => ImageType::Bitmap,
+            0 => ImageType::Bitmap,
             _ => ImageType::Reserved,
         }
     }
 
+    /// Gets the orientation offset of the image.
+    /// Degrees are clockwise from the images default orientation.
     pub fn orientation_offset(&self) -> u16 {
         let status = self.status;
-        match status.get_bits(1 .. 3) {
-            0=> 0,
+        match status.get_bits(1..3) {
+            0 => 0,
             1 => 90,
             2 => 180,
             3 => 270,
-            _ => unimplemented!(), // will never happen
+            _ => unreachable!(), // will never happen
         }
     }
 
@@ -57,4 +61,3 @@ pub enum ImageType {
     Bitmap,
     Reserved,
 }
-

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -55,13 +55,13 @@ extern crate alloc;
 #[cfg(test)]
 extern crate std;
 
+pub mod bgrt;
 pub mod fadt;
 pub mod hpet;
 pub mod madt;
 pub mod mcfg;
 pub mod platform;
 pub mod sdt;
-pub mod bgrt;
 
 pub use crate::{
     fadt::PowerProfile,


### PR DESCRIPTION
This commit adds the BGRT as specified in [SEC. 5.2.22 of the ACPI specification](https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#boot-graphics-resource-table-bgrt). The BGRT is
used for notifying OSPM of any boot graphics displayed by firmware during the boot process.

Signed-off-by: Ethin Probst <ethindp@protonmail.com>
