### PR TITLE
Make AML PciRoutingTable::route call LinkObject methods when required

### DIFF
--- a/aml/src/pci_routing.rs
+++ b/aml/src/pci_routing.rs
@@ -172,10 +172,10 @@ impl PciRoutingTable {
                 irq: gsi,
             }),
             PciRouteType::LinkObject(ref name) => {
-                let link_crs =
-                    context.namespace.get_by_path(&AmlName::from_str("_CRS").unwrap().resolve(name)?)?;
+                let path = AmlName::from_str("_CRS").unwrap().resolve(name)?;
+                let link_crs = context.invoke_method(&path, Args::EMPTY)?;
 
-                let resources = resource::resource_descriptor_list(link_crs)?;
+                let resources = resource::resource_descriptor_list(&link_crs)?;
                 match resources.as_slice() {
                     [Resource::Irq(descriptor)] => Ok(descriptor.clone()),
                     _ => Err(AmlError::UnexpectedResourceType),

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -605,6 +605,8 @@ impl AmlValue {
 pub struct Args(pub [Option<AmlValue>; 7]);
 
 impl Args {
+    pub const EMPTY: Self = Self([None, None, None, None, None, None, None]);
+
     pub fn from_list(list: Vec<AmlValue>) -> Result<Args, AmlError> {
         use core::convert::TryInto;
 


### PR DESCRIPTION
I was trying to use `PciRoutingTable` module in my kernel with Bochs emulator. In the defalt configuration the PCI `_PTR` entries have `LinkObjects` refer to methods that return buffers ([Bochs bios asl source code](https://github.com/ipxe/bochs/blob/master/bios/acpi-dsdt.dsl)). The current code expects to have only buffers themselves in that position. This PR makes `PciRoutingTable::route` call the method instead of returning a conversion error, as [defined in the ACPI spec](https://uefi.org/specs/ACPI/6.4/06_Device_Configuration/Device_Configuration.html#crs-current-resource-settings).
