### PR TITLE
shrink unsafe block

### DIFF
--- a/acpi/src/mcfg.rs
+++ b/acpi/src/mcfg.rs
@@ -66,10 +66,10 @@ impl Mcfg {
         // (see rust-osdev/acpi#58)
         let num_entries = length / mem::size_of::<McfgEntry>();
 
-        unsafe {
-            let pointer = (self as *const Mcfg as *const u8).add(mem::size_of::<Mcfg>()) as *const McfgEntry;
+        
+            let pointer = unsafe { (self as *const Mcfg as *const u8).add(mem::size_of::<Mcfg>()) as *const McfgEntry };
             slice::from_raw_parts(pointer, num_entries)
-        }
+        
     }
 }
 


### PR DESCRIPTION
@IsaacWoods Hi, In this function you use the unsafe keyword for some safe expressions. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 