### PR TITLE
fix `HpetInfo::num_comparators`

### DIFF
--- a/acpi/src/hpet.rs
+++ b/acpi/src/hpet.rs
@@ -57,7 +57,7 @@ impl HpetInfo {
     }
 
     pub fn num_comparators(&self) -> u8 {
-        self.event_timer_block_id.get_bits(8..13) as u8
+        self.event_timer_block_id.get_bits(8..13) as u8 + 1
     }
 
     pub fn main_counter_is_64bits(&self) -> bool {


### PR DESCRIPTION
This pr fixes the getter for the number of comparators for HPET.

>  The number in this field indicates the last timer (i.e. if there are three timers, the value will be 02h, four timers will be 03h, five timers will be 04h, etc.).
> (IA-PC HPET Specification)