### PR TITLE
Various comments, fix `PM_TMR_BLK` checking of `PM_TMR_LEN` to match spec

### DIFF
--- a/acpi/src/platform/interrupt.rs
+++ b/acpi/src/platform/interrupt.rs
@@ -15,26 +15,39 @@ pub struct NmiLine {
     pub line: LocalInterruptLine,
 }
 
-#[derive(Debug)]
+/// Indicates which local interrupt line will be utilized by an external interrupt. Specifically,
+/// these lines directly correspond to their requisite LVT entries in a processor's APIC.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LocalInterruptLine {
     Lint0,
     Lint1,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NmiProcessor {
     All,
     ProcessorUid(u32),
 }
 
-#[derive(Debug)]
+/// Polarity indicates what signal mode the interrupt line needs to be in to be considered 'active'.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Polarity {
     SameAsBus,
     ActiveHigh,
     ActiveLow,
 }
 
-#[derive(Debug)]
+/// Trigger mode of an interrupt, describing how the interrupt is triggered.
+///
+/// When an interrupt is `Edge` triggered, it is triggered exactly once, when the interrupt
+/// signal goes from its opposite polarity to its active polarity.
+///
+/// For `Level` triggered interrupts, a continuous signal is emitted so long as the interrupt
+/// is in its active polarity.
+///
+/// `SameAsBus`-triggered interrupts will utilize the same interrupt triggering as the system bus
+/// they communicate across.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TriggerMode {
     SameAsBus,
     Edge,

--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -661,7 +661,7 @@ impl AmlContext {
     }
 }
 
-// TODO: docs
+/// Trait type used by [`AmlContext`] to handle reading and writing to various types of memory in the system.
 pub trait Handler: Send + Sync {
     fn read_u8(&self, address: usize) -> u8;
     fn read_u16(&self, address: usize) -> u16;
@@ -694,6 +694,7 @@ pub trait Handler: Send + Sync {
     }
 }
 
+/// Used when an [`AmlContext`] encounters an error.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum AmlError {
     /*


### PR DESCRIPTION
This PR adjusts the construction of the `GenericAddress` for `pm_timer_block` to always check the `PM_TMR_LEN` value in the FADT. The ACPI spec indicates this value must be `4`, otherwise the PM_TMR isn't supported.

Additionally, `Clone, Copy, PartialEq, Eq` derive traits were added to `Polarity`, `LocalInterruptLine`, and `TriggerMode`.

Some comments, too.