### PR TITLE
Improve the PCIe configuration space interface

### DIFF
--- a/acpi/Cargo.toml
+++ b/acpi/Cargo.toml
@@ -10,6 +10,10 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-log = "0.4"
 bit_field = "0.10"
 rsdp = { version = "2", path = "../rsdp" }
+log = { version = "0.4", optional = true }
+
+[features]
+default = ["logging"]
+logging = ["log"]

--- a/acpi/Cargo.toml
+++ b/acpi/Cargo.toml
@@ -15,5 +15,6 @@ rsdp = { version = "2", path = "../rsdp" }
 log = { version = "0.4", optional = true }
 
 [features]
-default = ["logging"]
+default = ["logging", "alloc"]
 logging = ["log"]
+alloc = []

--- a/acpi/src/bgrt.rs
+++ b/acpi/src/bgrt.rs
@@ -16,6 +16,8 @@ pub struct Bgrt {
 }
 
 impl AcpiTable for Bgrt {
+    const SIGNATURE: crate::Signature = crate::Signature::BGRT;
+
     fn header(&self) -> &SdtHeader {
         &self.header
     }

--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -115,6 +115,8 @@ pub struct Fadt {
 }
 
 impl AcpiTable for Fadt {
+    const SIGNATURE: crate::Signature = crate::Signature::FADT;
+
     fn header(&self) -> &SdtHeader {
         &self.header
     }

--- a/acpi/src/hpet.rs
+++ b/acpi/src/hpet.rs
@@ -86,6 +86,8 @@ pub struct HpetTable {
 }
 
 impl AcpiTable for HpetTable {
+    const SIGNATURE: crate::Signature = crate::Signature::HPET;
+
     fn header(&self) -> &SdtHeader {
         &self.header
     }

--- a/acpi/src/hpet.rs
+++ b/acpi/src/hpet.rs
@@ -1,4 +1,8 @@
-use crate::{platform::address::RawGenericAddress, sdt::SdtHeader, AcpiError, AcpiHandler, AcpiTable, AcpiTables};
+use crate::{platform::address::RawGenericAddress, sdt::SdtHeader, AcpiTable};
+
+#[cfg(feature = "alloc")]
+use crate::{AcpiError, AcpiHandler, AcpiTables};
+#[cfg(feature = "alloc")]
 use bit_field::BitField;
 
 #[derive(Debug)]
@@ -12,6 +16,7 @@ pub enum PageProtection {
 }
 
 /// Information about the High Precision Event Timer (HPET)
+#[cfg(feature = "alloc")]
 #[derive(Debug)]
 pub struct HpetInfo {
     // TODO(3.0.0): unpack these fields directly, and get rid of methods
@@ -23,6 +28,7 @@ pub struct HpetInfo {
     pub page_protection: PageProtection,
 }
 
+#[cfg(feature = "alloc")]
 impl HpetInfo {
     pub fn new<H>(tables: &AcpiTables<H>) -> Result<HpetInfo, AcpiError>
     where

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -172,6 +172,10 @@ where
             if mapping.mapped_length() >= (mapping.length as usize) {
                 mapping
             } else {
+                // Drop the old mapping here, to ensure it's unmapped in software before requesting an overlapping mapping.
+                drop(mapping);
+
+                // SAFETY: Same as above safety message.
                 unsafe { result.handler.map_physical_region::<SdtHeader>(rsdt_address, mapping.length as usize) }
             }
         };

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -172,11 +172,12 @@ where
             if mapping.mapped_length() >= (mapping.length as usize) {
                 mapping
             } else {
+                let sdt_length = mapping.length;
                 // Drop the old mapping here, to ensure it's unmapped in software before requesting an overlapping mapping.
                 drop(mapping);
 
                 // SAFETY: Same as above safety message.
-                unsafe { result.handler.map_physical_region::<SdtHeader>(rsdt_address, mapping.length as usize) }
+                unsafe { result.handler.map_physical_region::<SdtHeader>(rsdt_address, sdt_length as usize) }
             }
         };
 

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -99,6 +99,19 @@ pub enum AcpiError {
     InvalidGenericAddress,
 }
 
+pub struct RsdpReader<H: AcpiHandler> {
+    mapping: PhysicalMapping<H, Rsdp>,
+}
+
+impl<H: AcpiHandler> RsdpReader<H> {
+    pub fn from_address(address: usize) -> Result<Self, AcpiError> {
+        let rsdp_mapping = unsafe { handler.map_physical_region::<Rsdp>(rsdp_address, mem::size_of::<Rsdp>()) };
+        rsdp_mapping.validate().map_err(AcpiError::Rsdp)?;
+
+        Self::from_validated_rsdp(handler, rsdp_mapping)
+    }
+}
+
 pub struct AcpiTables<H>
 where
     H: AcpiHandler,

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -100,32 +100,6 @@ pub enum AcpiError {
 
 pub type AcpiResult<T> = core::result::Result<T, AcpiError>;
 
-#[repr(C)]
-pub struct Rsdt {
-    header: SdtHeader,
-}
-
-impl AcpiTable for Rsdt {
-    const SIGNATURE: Signature = Signature::RSDT;
-
-    fn header(&self) -> &sdt::SdtHeader {
-        &self.header
-    }
-}
-
-#[repr(C)]
-pub struct Xsdt {
-    header: SdtHeader,
-}
-
-impl AcpiTable for Xsdt {
-    const SIGNATURE: Signature = Signature::XSDT;
-
-    fn header(&self) -> &sdt::SdtHeader {
-        &self.header
-    }
-}
-
 pub struct RootTable<H: AcpiHandler> {
     mapping: PhysicalMapping<H, SdtHeader>,
     revision: u8,

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -50,6 +50,7 @@
 #![no_std]
 #![deny(unsafe_op_in_unsafe_fn)]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg_attr(test, macro_use)]
 #[cfg(test)]
@@ -76,6 +77,7 @@ pub use rsdp::{
 };
 
 use crate::sdt::{SdtHeader, Signature};
+#[cfg(feature = "alloc")]
 use alloc::{collections::BTreeMap, vec::Vec};
 use core::mem;
 use log::trace;
@@ -103,8 +105,11 @@ where
 {
     /// The revision of ACPI that the system uses, as inferred from the revision of the RSDT/XSDT.
     pub revision: u8,
+    #[cfg(feature = "alloc")]
     pub sdts: BTreeMap<sdt::Signature, Sdt>,
+    #[cfg(feature = "alloc")]
     pub dsdt: Option<AmlTable>,
+    #[cfg(feature = "alloc")]
     pub ssdts: Vec<AmlTable>,
     handler: H,
 }

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -67,7 +67,7 @@ pub use crate::{
     fadt::PowerProfile,
     hpet::HpetInfo,
     madt::MadtError,
-    mcfg::PciConfigEntries,
+    mcfg::PciConfig,
     platform::{interrupt::InterruptModel, PlatformInfo},
 };
 pub use rsdp::{

--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -1,28 +1,30 @@
 use crate::{
-    platform::{
-        interrupt::{
-            Apic,
-            InterruptModel,
-            InterruptSourceOverride,
-            IoApic,
-            LocalInterruptLine,
-            NmiLine,
-            NmiProcessor,
-            NmiSource,
-            Polarity,
-            TriggerMode,
-        },
-        Processor,
-        ProcessorInfo,
-        ProcessorState,
-    },
+    platform::interrupt::{Polarity, TriggerMode},
     sdt::SdtHeader,
     AcpiError,
     AcpiTable,
 };
-use alloc::vec::Vec;
 use bit_field::BitField;
 use core::{marker::PhantomData, mem};
+
+#[cfg(feature = "alloc")]
+use crate::platform::{
+    interrupt::{
+        Apic,
+        InterruptModel,
+        InterruptSourceOverride,
+        IoApic,
+        LocalInterruptLine,
+        NmiLine,
+        NmiProcessor,
+        NmiSource,
+    },
+    Processor,
+    ProcessorInfo,
+    ProcessorState,
+};
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 #[derive(Debug)]
 pub enum MadtError {
@@ -57,6 +59,7 @@ impl AcpiTable for Madt {
 }
 
 impl Madt {
+    #[cfg(feature = "alloc")]
     pub fn parse_interrupt_model(&self) -> Result<(InterruptModel, Option<ProcessorInfo>), AcpiError> {
         /*
          * We first do a pass through the MADT to determine which interrupt model is being used.
@@ -95,6 +98,7 @@ impl Madt {
         Ok((InterruptModel::Unknown, None))
     }
 
+    #[cfg(feature = "alloc")]
     fn parse_apic_model(&self) -> Result<(InterruptModel, Option<ProcessorInfo>), AcpiError> {
         let mut local_apic_address = self.local_apic_address as u64;
         let mut io_apic_count = 0;

--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -159,6 +159,7 @@ impl Madt {
                         (true, false) => ProcessorState::WaitingForSipi,
                         (false, false) => ProcessorState::Running,
                     };
+                    #[cfg(feature = "logging")]
                     log::info!("Found X2APIC in MADT!");
 
                     let processor = Processor {

--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -49,6 +49,8 @@ pub struct Madt {
 }
 
 impl AcpiTable for Madt {
+    const SIGNATURE: crate::Signature = crate::Signature::MADT;
+
     fn header(&self) -> &SdtHeader {
         &self.header
     }

--- a/acpi/src/mcfg.rs
+++ b/acpi/src/mcfg.rs
@@ -59,7 +59,11 @@ impl AcpiTable for Mcfg {
 }
 
 impl Mcfg {
-    fn entries(&self) -> &[McfgEntry] {
+    /// Creates a bare slice over the MCFG entry table.
+    ///
+    /// # Remark: It is suggested to construct and use the `PciConfigRegions` type instead, if possible, as it provides a
+    ///           safe wrapper around the PCI device memory.
+    pub fn entries(&self) -> &[McfgEntry] {
         let length = self.header.length as usize - mem::size_of::<Mcfg>();
 
         // Intentionally round down in case length isn't an exact multiple of McfgEntry size
@@ -73,12 +77,13 @@ impl Mcfg {
     }
 }
 
+/// Entry type for the MCFG ACPI table.
 #[derive(Clone, Copy, Debug)]
 #[repr(C, packed)]
 pub struct McfgEntry {
-    base_address: u64,
-    pci_segment_group: u16,
-    bus_number_start: u8,
-    bus_number_end: u8,
+    pub base_address: u64,
+    pub pci_segment_group: u16,
+    pub bus_number_start: u8,
+    pub bus_number_end: u8,
     _reserved: u32,
 }

--- a/acpi/src/mcfg.rs
+++ b/acpi/src/mcfg.rs
@@ -1,12 +1,17 @@
+#[cfg(feature = "alloc")]
+use crate::{AcpiError, AcpiHandler, AcpiTables};
+#[cfg(feature = "alloc")]
 use rsdp::handler::PhysicalMapping;
 
-use crate::{sdt::SdtHeader, AcpiError, AcpiHandler, AcpiTable, AcpiTables};
+use crate::{sdt::SdtHeader, AcpiTable};
 use core::{mem, slice};
 
 /// Describes a set of regions of physical memory used to access the PCIe configuration space. An
 /// entry is created for each entry in the MCFG.
+#[cfg(feature = "alloc")]
 pub struct PciConfig<H: AcpiHandler>(PhysicalMapping<H, Mcfg>);
 
+#[cfg(feature = "alloc")]
 impl<H> PciConfig<H>
 where
     H: AcpiHandler,

--- a/acpi/src/mcfg.rs
+++ b/acpi/src/mcfg.rs
@@ -11,7 +11,8 @@ impl<H> PciConfig<H>
 where
     H: AcpiHandler,
 {
-    /// Creates a new `PciConfigEntries` structure, encapsulating the relevant information about the system's PCI configuration space.
+    /// Creates a new [`PciConfig`] structure, encapsulating the relevant information about the system's
+    /// PCIe configuration space.
     pub fn new(tables: &AcpiTables<H>) -> Result<Self, AcpiError> {
         Ok(Self(unsafe {
             tables
@@ -40,6 +41,7 @@ where
     }
 
     /// Returns an iterator providing information about the system's present PCI busses.
+    /// This is roughly equivalent to manually iterating the system's MCFG table.
     pub fn iter(&self) -> PciConfigEntryIterator {
         PciConfigEntryIterator { entries: self.0.entries(), index: 0 }
     }
@@ -52,7 +54,7 @@ pub struct PciConfigEntry {
     pub physical_address: usize,
 }
 
-/// Iterator providing a `PciConfigEntry` for all of the valid bus ranges on the system.
+/// Iterator providing a [`PciConfigEntry`] for all of the valid bus ranges on the system.
 pub struct PciConfigEntryIterator<'a> {
     entries: &'a [McfgEntry],
     index: usize,

--- a/acpi/src/mcfg.rs
+++ b/acpi/src/mcfg.rs
@@ -83,6 +83,8 @@ pub struct Mcfg {
 }
 
 impl AcpiTable for Mcfg {
+    const SIGNATURE: crate::Signature = crate::Signature::MCFG;
+
     fn header(&self) -> &SdtHeader {
         &self.header
     }

--- a/acpi/src/mcfg.rs
+++ b/acpi/src/mcfg.rs
@@ -4,13 +4,13 @@ use core::{mem, slice};
 /// Describes a set of regions of physical memory used to access the PCIe configuration space. An
 /// entry is created for each entry in the MCFG.
 #[derive(Clone, Debug)]
-pub struct PciConfigEntries<'a> {
+pub struct PciConfig<'a> {
     entries: &'a [McfgEntry],
 }
 
-impl<'a> PciConfigEntries<'a> {
+impl<'a> PciConfig<'a> {
     /// Creates a new `PciConfigEntries` structure, encapsulating the relevant information about the system's PCI configuration space.
-    pub fn new<H>(tables: &'a AcpiTables<H>) -> Result<PciConfigEntries, AcpiError>
+    pub fn new<H>(tables: &'a AcpiTables<H>) -> Result<PciConfig, AcpiError>
     where
         H: AcpiHandler,
     {
@@ -24,7 +24,7 @@ impl<'a> PciConfigEntries<'a> {
             let entries = mcfg.entries();
             // SAFETY: We're simply reconstructing an existing slice to elide the local lifetime (for the higher-context
             //         lifetime of the `AcpiTables<H>`, which this type is bound to via `'a`).
-            PciConfigEntries { entries: unsafe { core::slice::from_raw_parts(entries.as_ptr(), entries.len()) } }
+            PciConfig { entries: unsafe { core::slice::from_raw_parts(entries.as_ptr(), entries.len()) } }
         })
     }
 

--- a/acpi/src/mcfg.rs
+++ b/acpi/src/mcfg.rs
@@ -10,7 +10,10 @@ pub struct PciConfigEntries<'a> {
 
 impl<'a> PciConfigEntries<'a> {
     /// Creates a new `PciConfigEntries` structure, encapsulating the relevant information about the system's PCI configuration space.
-    pub fn new<H: AcpiHandler>(tables: &'a AcpiTables<H>) -> Result<PciConfigEntries, AcpiError> {
+    pub fn new<H>(tables: &'a AcpiTables<H>) -> Result<PciConfigEntries, AcpiError>
+    where
+        H: AcpiHandler,
+    {
         let mcfg = unsafe {
             tables
                 .get_sdt::<Mcfg>(crate::sdt::Signature::MCFG)?

--- a/acpi/src/platform/interrupt.rs
+++ b/acpi/src/platform/interrupt.rs
@@ -15,26 +15,39 @@ pub struct NmiLine {
     pub line: LocalInterruptLine,
 }
 
-#[derive(Debug)]
+/// Indicates which local interrupt line will be utilized by an external interrupt. Specifically,
+/// these lines directly correspond to their requisite LVT entries in a processor's APIC.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LocalInterruptLine {
     Lint0,
     Lint1,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NmiProcessor {
     All,
     ProcessorUid(u32),
 }
 
-#[derive(Debug)]
+/// Polarity indicates what signal mode the interrupt line needs to be in to be considered 'active'.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Polarity {
     SameAsBus,
     ActiveHigh,
     ActiveLow,
 }
 
-#[derive(Debug)]
+/// Trigger mode of an interrupt, describing how the interrupt is triggered.
+///
+/// When an interrupt is `Edge` triggered, it is triggered exactly once, when the interrupt
+/// signal goes from its opposite polarity to its active polarity.
+///
+/// For `Level` triggered interrupts, a continuous signal is emitted so long as the interrupt
+/// is in its active polarity.
+///
+/// `SameAsBus`-triggered interrupts will utilize the same interrupt triggering as the system bus
+/// they communicate across.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TriggerMode {
     SameAsBus,
     Edge,

--- a/acpi/src/platform/interrupt.rs
+++ b/acpi/src/platform/interrupt.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 #[derive(Debug)]
@@ -75,6 +76,7 @@ pub struct NmiSource {
     pub trigger_mode: TriggerMode,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Debug)]
 pub struct Apic {
     pub local_apic_address: u64,
@@ -89,6 +91,7 @@ pub struct Apic {
     pub also_has_legacy_pics: bool,
 }
 
+#[cfg(feature = "alloc")]
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum InterruptModel {

--- a/acpi/src/platform/mod.rs
+++ b/acpi/src/platform/mod.rs
@@ -60,6 +60,18 @@ impl PmTimer {
     }
 }
 
+pub struct Pm1Event {
+    pm1a_status: GenericAddress,
+    pm1a_enable: GenericAddress,
+    pm1b_status: Option<GenericAddress>,
+    pm1b_enable: Option<GenericAddress>,
+}
+
+pub struct Pm1Control {
+    pm1a: GenericAddress,
+    pm1b: Option<GenericAddress>,
+}
+
 /// `PlatformInfo` allows the collection of some basic information about the platform from some of the fixed-size
 /// tables in a nice way. It requires access to the `FADT` and `MADT`. It is the easiest way to get information
 /// about the processors and interrupt controllers on a platform.
@@ -70,6 +82,8 @@ pub struct PlatformInfo {
     /// interrupt model. That information is stored here, if present.
     pub processor_info: Option<ProcessorInfo>,
     pub pm_timer: Option<PmTimer>,
+    pub pm1_event: Pm1Event,
+    pub pm1_control: Pm1Control,
     /*
      * TODO: we could provide a nice view of the hardware register blocks in the FADT here.
      */

--- a/acpi/src/platform/mod.rs
+++ b/acpi/src/platform/mod.rs
@@ -60,18 +60,6 @@ impl PmTimer {
     }
 }
 
-pub struct Pm1Event {
-    pm1a_status: GenericAddress,
-    pm1a_enable: GenericAddress,
-    pm1b_status: Option<GenericAddress>,
-    pm1b_enable: Option<GenericAddress>,
-}
-
-pub struct Pm1Control {
-    pm1a: GenericAddress,
-    pm1b: Option<GenericAddress>,
-}
-
 /// `PlatformInfo` allows the collection of some basic information about the platform from some of the fixed-size
 /// tables in a nice way. It requires access to the `FADT` and `MADT`. It is the easiest way to get information
 /// about the processors and interrupt controllers on a platform.
@@ -82,8 +70,6 @@ pub struct PlatformInfo {
     /// interrupt model. That information is stored here, if present.
     pub processor_info: Option<ProcessorInfo>,
     pub pm_timer: Option<PmTimer>,
-    pub pm1_event: Pm1Event,
-    pub pm1_control: Pm1Control,
     /*
      * TODO: we could provide a nice view of the hardware register blocks in the FADT here.
      */

--- a/acpi/src/platform/mod.rs
+++ b/acpi/src/platform/mod.rs
@@ -1,10 +1,13 @@
 pub mod address;
 pub mod interrupt;
 
-use crate::{fadt::Fadt, madt::Madt, AcpiError, AcpiHandler, AcpiTables, PowerProfile};
-use address::GenericAddress;
+#[cfg(feature = "alloc")]
+use crate::{madt::Madt, AcpiHandler, AcpiTables, InterruptModel, PowerProfile};
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-use interrupt::InterruptModel;
+
+use crate::{fadt::Fadt, AcpiError};
+use address::GenericAddress;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ProcessorState {
@@ -37,6 +40,7 @@ pub struct Processor {
     pub is_ap: bool,
 }
 
+#[cfg(feature = "alloc")]
 pub struct ProcessorInfo {
     pub boot_processor: Processor,
     /// Application processors should be brought up in the order they're defined in this list.
@@ -63,6 +67,7 @@ impl PmTimer {
 /// `PlatformInfo` allows the collection of some basic information about the platform from some of the fixed-size
 /// tables in a nice way. It requires access to the `FADT` and `MADT`. It is the easiest way to get information
 /// about the processors and interrupt controllers on a platform.
+#[cfg(feature = "alloc")]
 pub struct PlatformInfo {
     pub power_profile: PowerProfile,
     pub interrupt_model: InterruptModel,
@@ -75,6 +80,7 @@ pub struct PlatformInfo {
      */
 }
 
+#[cfg(feature = "alloc")]
 impl PlatformInfo {
     pub fn new<H>(tables: &AcpiTables<H>) -> Result<PlatformInfo, AcpiError>
     where

--- a/acpi/src/sdt.rs
+++ b/acpi/src/sdt.rs
@@ -246,11 +246,13 @@ impl fmt::Debug for Signature {
 
 /// Takes the physical address of an SDT, and maps, clones and unmaps its header. Useful for
 /// finding out how big it is to map it correctly later.
-pub(crate) fn peek_at_sdt_header<H>(handler: &H, physical_address: usize) -> SdtHeader
+pub(crate) fn peek_at_sdt_header<H>(
+    handler: &H,
+    physical_address: usize,
+) -> rsdp::handler::PhysicalMapping<H, SdtHeader>
 where
     H: AcpiHandler,
 {
-    let mapping =
-        unsafe { handler.map_physical_region::<SdtHeader>(physical_address, mem::size_of::<SdtHeader>()) };
-    *mapping
+    // SAFETY: Physical address is valid for the size of `SdtHeader`.
+    unsafe { handler.map_physical_region::<SdtHeader>(physical_address, mem::size_of::<SdtHeader>()) }
 }

--- a/acpi/src/sdt.rs
+++ b/acpi/src/sdt.rs
@@ -243,16 +243,3 @@ impl fmt::Debug for Signature {
         write!(f, "\"{}\"", self.as_str())
     }
 }
-
-/// Takes the physical address of an SDT, and maps, clones and unmaps its header. Useful for
-/// finding out how big it is to map it correctly later.
-pub(crate) fn peek_at_sdt_header<H>(
-    handler: &H,
-    physical_address: usize,
-) -> rsdp::handler::PhysicalMapping<H, SdtHeader>
-where
-    H: AcpiHandler,
-{
-    // SAFETY: Physical address is valid for the size of `SdtHeader`.
-    unsafe { handler.map_physical_region::<SdtHeader>(physical_address, mem::size_of::<SdtHeader>()) }
-}

--- a/acpi/src/sdt.rs
+++ b/acpi/src/sdt.rs
@@ -243,3 +243,14 @@ impl fmt::Debug for Signature {
         write!(f, "\"{}\"", self.as_str())
     }
 }
+
+/// Takes the physical address of an SDT, and maps, clones and unmaps its header. Useful for
+/// finding out how big it is to map it correctly later.
+pub(crate) fn peek_at_sdt_header<H>(handler: &H, physical_address: usize) -> SdtHeader
+where
+    H: AcpiHandler,
+{
+    let mapping =
+        unsafe { handler.map_physical_region::<SdtHeader>(physical_address, mem::size_of::<SdtHeader>()) };
+    *mapping
+}

--- a/acpi/src/sdt.rs
+++ b/acpi/src/sdt.rs
@@ -135,7 +135,10 @@ impl SdtHeader {
         let self_ptr = self as *const SdtHeader as *const u8;
         let mut sum: u8 = 0;
         for i in 0..self.length {
-            sum = sum.wrapping_add(unsafe { *(self_ptr.offset(i as isize)) } as u8);
+            sum = sum.wrapping_add(
+                // SAFETY: Table length is known-good for byte-sized reads.
+                unsafe { self_ptr.offset(i as isize).read_unaligned() },
+            );
         }
 
         if sum > 0 {

--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -661,7 +661,7 @@ impl AmlContext {
     }
 }
 
-// TODO: docs
+/// Trait type used by [`AmlContext`] to handle reading and writing to various types of memory in the system.
 pub trait Handler: Send + Sync {
     fn read_u8(&self, address: usize) -> u8;
     fn read_u16(&self, address: usize) -> u16;
@@ -694,6 +694,7 @@ pub trait Handler: Send + Sync {
     }
 }
 
+/// Used when an [`AmlContext`] encounters an error.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum AmlError {
     /*

--- a/rsdp/src/handler.rs
+++ b/rsdp/src/handler.rs
@@ -1,5 +1,6 @@
 use core::{ops::Deref, ptr::NonNull};
 
+
 /// Describes a physical mapping created by `AcpiHandler::map_physical_region` and unmapped by
 /// `AcpiHandler::unmap_physical_region`. The region mapped must be at least `size_of::<T>()`
 /// bytes, but may be bigger.


### PR DESCRIPTION
The primary focus here is improving the interface used by `PlatformInfo` to enumerate the PCIe configuration space. While the current enumeration via `PciConfig::physical_address` tends to be flexible enough for most implementations, a more involved implementation dealing with multi-socket or generally separated PCI host controllers (and so, dealing in separate segment groups) was not possible. This set of commits should solve that issue.

*remark: for some reason (I'm no git expert) this PR also contains the commits from a previous PR already merged, namely #123. If this causes issues, I can refork from `main` and re-apply these changes.*