### PR TITLE
rework crate to allocationless

### DIFF
--- a/acpi/Cargo.toml
+++ b/acpi/Cargo.toml
@@ -10,6 +10,9 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-log = "0.4"
 bit_field = "0.10"
 rsdp = { version = "2", path = "../rsdp" }
+
+[features]
+default = ["allocator_api"]
+allocator_api = []

--- a/acpi/src/address.rs
+++ b/acpi/src/address.rs
@@ -6,7 +6,7 @@ use core::convert::TryFrom;
 
 /// This is the raw form of a Generic Address Structure, and follows the layout found in the ACPI tables. It does
 /// not form part of the public API, and should be turned into a `GenericAddress` for most use-cases.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub(crate) struct RawGenericAddress {
     pub address_space: u8,
@@ -16,7 +16,7 @@ pub(crate) struct RawGenericAddress {
     pub address: u64,
 }
 
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AddressSpace {
     SystemMemory,
     SystemIo,
@@ -41,7 +41,7 @@ pub enum AddressSpace {
     OemDefined(u8),
 }
 
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccessSize {
     Undefined,
     ByteAccess,
@@ -75,7 +75,7 @@ pub struct GenericAddress {
 }
 
 impl GenericAddress {
-    pub(crate) fn from_raw(raw: RawGenericAddress) -> Result<GenericAddress, AcpiError> {
+    pub(crate) fn from_raw(raw: RawGenericAddress) -> crate::AcpiResult<GenericAddress> {
         let address_space = match raw.address_space {
             0x00 => AddressSpace::SystemMemory,
             0x01 => AddressSpace::SystemIo,

--- a/acpi/src/bgrt.rs
+++ b/acpi/src/bgrt.rs
@@ -1,4 +1,7 @@
-use crate::{sdt::SdtHeader, AcpiTable};
+use crate::{
+    sdt::{SdtHeader, Signature},
+    AcpiTable,
+};
 use bit_field::BitField;
 
 /// The BGRT table contains information about a boot graphic that was displayed
@@ -15,7 +18,10 @@ pub struct Bgrt {
     image_offset_y: u32,
 }
 
-impl AcpiTable for Bgrt {
+/// ### Safety: Implementation properly represents a valid BGRT.
+unsafe impl AcpiTable for Bgrt {
+    const SIGNATURE: Signature = Signature::BGRT;
+
     fn header(&self) -> &SdtHeader {
         &self.header
     }
@@ -56,7 +62,7 @@ impl Bgrt {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum ImageType {
     Bitmap,
     Reserved,

--- a/acpi/src/fadt.rs
+++ b/acpi/src/fadt.rs
@@ -1,12 +1,12 @@
 use crate::{
-    platform::address::{AccessSize, AddressSpace, GenericAddress, RawGenericAddress},
-    sdt::{ExtendedField, SdtHeader},
+    address::{AccessSize, AddressSpace, GenericAddress, RawGenericAddress},
+    sdt::{ExtendedField, SdtHeader, Signature},
     AcpiError,
     AcpiTable,
 };
 use bit_field::BitField;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PowerProfile {
     Unspecified,
     Desktop,
@@ -115,7 +115,10 @@ pub struct Fadt {
     hypervisor_vendor_id: ExtendedField<u64, 2>,
 }
 
-impl AcpiTable for Fadt {
+/// ### Safety: Implementation properly represents a valid FADT.
+unsafe impl AcpiTable for Fadt {
+    const SIGNATURE: Signature = Signature::FADT;
+
     fn header(&self) -> &SdtHeader {
         &self.header
     }
@@ -345,7 +348,7 @@ impl Fadt {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct FixedFeatureFlags(u32);
 
 impl FixedFeatureFlags {
@@ -465,7 +468,7 @@ impl FixedFeatureFlags {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct IaPcBootArchFlags(u16);
 
 impl IaPcBootArchFlags {
@@ -502,7 +505,7 @@ impl IaPcBootArchFlags {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct ArmBootArchFlags(u16);
 
 impl ArmBootArchFlags {

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -49,38 +49,60 @@
 
 #![no_std]
 #![deny(unsafe_op_in_unsafe_fn)]
+#![cfg_attr(feature = "allocator_api", feature(allocator_api, ptr_as_uninit))]
 
-extern crate alloc;
 #[cfg_attr(test, macro_use)]
 #[cfg(test)]
 extern crate std;
 
+pub mod address;
 pub mod bgrt;
 pub mod fadt;
 pub mod hpet;
 pub mod madt;
 pub mod mcfg;
-pub mod platform;
 pub mod sdt;
 
-pub use crate::{
-    fadt::PowerProfile,
-    hpet::HpetInfo,
-    madt::MadtError,
-    mcfg::PciConfigRegions,
-    platform::{interrupt::InterruptModel, PlatformInfo},
-};
+#[cfg(feature = "allocator_api")]
+mod managed_slice;
+#[cfg(feature = "allocator_api")]
+pub use managed_slice::*;
+
+#[cfg(feature = "allocator_api")]
+pub use crate::platform::{interrupt::InterruptModel, PlatformInfo};
+#[cfg(feature = "allocator_api")]
+pub mod platform;
+
+pub use crate::{fadt::PowerProfile, hpet::HpetInfo, madt::MadtError, mcfg::PciConfigRegions};
 pub use rsdp::{
     handler::{AcpiHandler, PhysicalMapping},
     RsdpError,
 };
 
 use crate::sdt::{SdtHeader, Signature};
-use alloc::{collections::BTreeMap, vec::Vec};
 use core::mem;
-use log::trace;
 use rsdp::Rsdp;
 
+/// Result type used by error-returning functions.
+pub type AcpiResult<T> = core::result::Result<T, AcpiError>;
+
+/// All types representing ACPI tables should implement this trait.
+///
+/// ### Safety: This trait requires the implementation to correctly lay out the memory
+/// it is attempting to represent. If, for instance, an invalid `T` is provided to
+/// `AcpiTables::find_table`, undefined behaviour would result from the enumeration of the
+/// headers.
+pub unsafe trait AcpiTable {
+    const SIGNATURE: Signature;
+
+    fn header(&self) -> &sdt::SdtHeader;
+
+    fn validate(&self) -> AcpiResult<()> {
+        self.header().validate(Self::SIGNATURE)
+    }
+}
+
+/// Error type used by functions that return an `AcpiResult<T>`.
 #[derive(Debug)]
 pub enum AcpiError {
     Rsdp(RsdpError),
@@ -95,18 +117,19 @@ pub enum AcpiError {
     InvalidDsdtAddress,
     InvalidMadt(MadtError),
     InvalidGenericAddress,
+
+    AllocError,
 }
 
+/// Type capable of enumerating the existing ACPI tables on the system.
+///
+/// ### Remark: If using the `allocator_api` is an option, `PlatformInfo::new()` should be used
+///             to enumerate relevant ACPI structures, as it provides a much cleaner interface to
+///             the data.
 #[derive(Debug)]
-pub struct AcpiTables<H>
-where
-    H: AcpiHandler,
-{
-    /// The revision of ACPI that the system uses, as inferred from the revision of the RSDT/XSDT.
-    pub revision: u8,
-    pub sdts: BTreeMap<sdt::Signature, Sdt>,
-    pub dsdt: Option<AmlTable>,
-    pub ssdts: Vec<AmlTable>,
+pub struct AcpiTables<H: AcpiHandler> {
+    mapping: PhysicalMapping<H, SdtHeader>,
+    revision: u8,
     handler: H,
 }
 
@@ -115,170 +138,150 @@ where
     H: AcpiHandler,
 {
     /// Create an `AcpiTables` if you have the physical address of the RSDP.
-    pub unsafe fn from_rsdp(handler: H, rsdp_address: usize) -> Result<AcpiTables<H>, AcpiError> {
-        let rsdp_mapping = unsafe { handler.map_physical_region::<Rsdp>(rsdp_address, mem::size_of::<Rsdp>()) };
+    ///
+    /// ### Safety: Caller must ensure the provided address is valid to read as an RSDP.
+    pub unsafe fn from_rsdp(handler: H, address: usize) -> AcpiResult<Self> {
+        let rsdp_mapping = unsafe { handler.map_physical_region::<Rsdp>(address, mem::size_of::<Rsdp>()) };
         rsdp_mapping.validate().map_err(AcpiError::Rsdp)?;
 
-        Self::from_validated_rsdp(handler, rsdp_mapping)
+        // ### Safety: `RSDP` has been validated.
+        unsafe { Self::from_validated_rsdp(handler, rsdp_mapping) }
     }
 
     /// Search for the RSDP on a BIOS platform. This accesses BIOS-specific memory locations and will probably not
     /// work on UEFI platforms. See [Rsdp::search_for_rsdp_bios](rsdp_search::Rsdp::search_for_rsdp_bios) for
     /// details.
-    pub unsafe fn search_for_rsdp_bios(handler: H) -> Result<AcpiTables<H>, AcpiError> {
+    pub unsafe fn search_for_rsdp_bios(handler: H) -> AcpiResult<Self> {
         let rsdp_mapping = unsafe { Rsdp::search_for_on_bios(handler.clone()) }.map_err(AcpiError::Rsdp)?;
-        Self::from_validated_rsdp(handler, rsdp_mapping)
+        // ### Safety: RSDP has been validated from `Rsdp::search_for_on_bios`
+        unsafe { Self::from_validated_rsdp(handler, rsdp_mapping) }
     }
 
     /// Create an `AcpiTables` if you have a `PhysicalMapping` of the RSDP that you know is correct. This is called
     /// from `from_rsdp` after validation, but can also be used if you've searched for the RSDP manually on a BIOS
     /// system.
-    pub fn from_validated_rsdp(
-        handler: H,
-        rsdp_mapping: PhysicalMapping<H, Rsdp>,
-    ) -> Result<AcpiTables<H>, AcpiError> {
+    ///
+    /// ### Safety: Caller must ensure that the provided mapping is a fully validated RSDP.
+    pub unsafe fn from_validated_rsdp(handler: H, rsdp_mapping: PhysicalMapping<H, Rsdp>) -> AcpiResult<Self> {
         let revision = rsdp_mapping.revision();
 
         if revision == 0 {
             /*
              * We're running on ACPI Version 1.0. We should use the 32-bit RSDT address.
              */
-            let rsdt_address = rsdp_mapping.rsdt_address();
-            unsafe { Self::from_rsdt(handler, revision, rsdt_address as usize) }
+
+            // ### Safety: Addresses from a validated `RSDP` are also guaranteed to be valid.
+            let rsdt_mapping: PhysicalMapping<H, SdtHeader> = unsafe {
+                handler.map_physical_region::<SdtHeader>(
+                    rsdp_mapping.rsdt_address() as usize,
+                    core::mem::size_of::<SdtHeader>(),
+                )
+            };
+            rsdt_mapping.validate(Signature::RSDT)?;
+
+            Ok(Self { mapping: rsdt_mapping, revision, handler })
         } else {
             /*
              * We're running on ACPI Version 2.0+. We should use the 64-bit XSDT address, truncated
              * to 32 bits on x86.
              */
-            let xsdt_address = rsdp_mapping.xsdt_address();
-            unsafe { Self::from_rsdt(handler, revision, xsdt_address as usize) }
+
+            // ### Safety: Addresses from a validated `RSDP` are also guaranteed to be valid.
+            let xsdt_mapping: PhysicalMapping<H, SdtHeader> = unsafe {
+                handler.map_physical_region::<SdtHeader>(
+                    rsdp_mapping.xsdt_address() as usize,
+                    core::mem::size_of::<SdtHeader>(),
+                )
+            };
+            xsdt_mapping.validate(Signature::XSDT)?;
+
+            Ok(Self { mapping: xsdt_mapping, revision, handler })
         }
     }
 
-    /// Create an `AcpiTables` if you have the physical address of the RSDT. This is useful, for example, if your chosen
-    /// bootloader reads the RSDP and passes you the address of the RSDT. You also need to supply the correct ACPI
-    /// revision - if `0`, a RSDT is expected, while a `XSDT` is expected for greater revisions.
-    pub unsafe fn from_rsdt(handler: H, revision: u8, rsdt_address: usize) -> Result<AcpiTables<H>, AcpiError> {
-        let mut result = AcpiTables { revision, sdts: BTreeMap::new(), dsdt: None, ssdts: Vec::new(), handler };
+    /// Searches through the ACPI table headers and attempts to locate the table with a matching `T::SIGNATURE`.
+    pub fn find_table<T: AcpiTable>(&self) -> AcpiResult<PhysicalMapping<H, T>> {
+        use core::mem::size_of;
 
-        let header = sdt::peek_at_sdt_header(&result.handler, rsdt_address);
-        let mapping =
-            unsafe { result.handler.map_physical_region::<SdtHeader>(rsdt_address, header.length as usize) };
+        if self.revision == 0 {
+            let num_tables = ((self.mapping.length as usize) - size_of::<SdtHeader>()) / size_of::<u32>();
+            // ### Safety: Table pointer is known-good for these offsets and types.
+            let tables_base = unsafe { self.mapping.virtual_start().as_ptr().add(1).cast::<u32>() };
 
-        if revision == 0 {
-            /*
-             * ACPI Version 1.0. It's a RSDT!
-             */
-            mapping.validate(sdt::Signature::RSDT)?;
+            for offset in 0..num_tables {
+                // ### Safety: Table pointer is known-good for these offsets and types.
+                let sdt_header_address = unsafe { tables_base.add(offset).read_unaligned() } as usize;
 
-            let num_tables = (mapping.length as usize - mem::size_of::<SdtHeader>()) / mem::size_of::<u32>();
-            let tables_base =
-                ((mapping.virtual_start().as_ptr() as usize) + mem::size_of::<SdtHeader>()) as *const u32;
-
-            for i in 0..num_tables {
-                result.process_sdt(unsafe { *tables_base.add(i) as usize })?;
+                // ### Safety: `RSDT` guarantees its contained addresses to be valid.
+                let table_result = unsafe { read_table(self.handler.clone(), sdt_header_address) };
+                if table_result.is_ok() {
+                    return table_result;
+                }
             }
         } else {
-            /*
-             * ACPI Version 2.0+. It's a XSDT!
-             */
-            mapping.validate(sdt::Signature::XSDT)?;
+            let num_tables = ((self.mapping.length as usize) - size_of::<SdtHeader>()) / size_of::<u64>();
+            // ### Safety: Table pointer is known-good for these offsets and types.
+            let tables_base = unsafe { self.mapping.virtual_start().as_ptr().add(1).cast::<u64>() };
 
-            let num_tables = (mapping.length as usize - mem::size_of::<SdtHeader>()) / mem::size_of::<u64>();
-            let tables_base =
-                ((mapping.virtual_start().as_ptr() as usize) + mem::size_of::<SdtHeader>()) as *const u64;
+            for offset in 0..num_tables {
+                // ### Safety: Table pointer is known-good for these offsets and types.
+                let sdt_header_address = unsafe { tables_base.add(offset).read_unaligned() } as usize;
 
-            for i in 0..num_tables {
-                result.process_sdt(unsafe { *tables_base.add(i) as usize })?;
+                // ### Safety: `RSDT` guarantees its contained addresses to be valid.
+                let table_result = unsafe { read_table(self.handler.clone(), sdt_header_address) };
+                if table_result.is_ok() {
+                    return table_result;
+                }
             }
         }
 
-        Ok(result)
+        Err(AcpiError::TableMissing(T::SIGNATURE))
     }
 
-    /// Construct an `AcpiTables` from a custom set of "discovered" tables. This is provided to allow the library
-    /// to be used from unconventional settings (e.g. in userspace), for example with a `AcpiHandler` that detects
-    /// accesses to specific physical addresses, and provides the correct data.
-    pub fn from_tables_direct(
-        handler: H,
-        revision: u8,
-        sdts: BTreeMap<sdt::Signature, Sdt>,
-        dsdt: Option<AmlTable>,
-        ssdts: Vec<AmlTable>,
-    ) -> AcpiTables<H> {
-        AcpiTables { revision, sdts, dsdt, ssdts, handler }
+    /// Finds and returns the DSDT AML table, if it exists.
+    pub fn dsdt(&self) -> AcpiResult<AmlTable> {
+        self.find_table::<fadt::Fadt>().and_then(|fadt| {
+            struct Dsdt;
+            // ### Safety: Implementation properly represents a valid DSDT.
+            unsafe impl AcpiTable for Dsdt {
+                const SIGNATURE: Signature = Signature::DSDT;
+
+                fn header(&self) -> &sdt::SdtHeader {
+                    // ### Safety: DSDT will always be valid for an SdtHeader at its `self` pointer.
+                    unsafe { &*(self as *const Self as *const sdt::SdtHeader) }
+                }
+            }
+
+            let dsdt_address = fadt.dsdt_address()?;
+            let dsdt = unsafe { read_table::<H, Dsdt>(self.handler.clone(), dsdt_address)? };
+
+            Ok(AmlTable::new(dsdt_address, dsdt.header().length))
+        })
     }
 
-    fn process_sdt(&mut self, physical_address: usize) -> Result<(), AcpiError> {
-        let header = sdt::peek_at_sdt_header(&self.handler, physical_address);
-        trace!("Found ACPI table with signature {:?} and length {:?}", header.signature, { header.length });
+    /// Iterates through all of the SSDT tables.
+    pub fn ssdts(&self) -> SsdtIterator<H> {
+        let table_base_address = unsafe { self.mapping.virtual_start().as_ptr().add(1) as usize };
+        let table_end_address = table_base_address
+            + (((self.mapping.length as usize) - mem::size_of::<SdtHeader>()) / mem::size_of::<u64>());
 
-        match header.signature {
-            Signature::FADT => {
-                use crate::fadt::Fadt;
-
-                /*
-                 * For whatever reason, they chose to put the DSDT inside the FADT, instead of just listing it
-                 * as another SDT. We extract it here to provide a nicer public API.
-                 */
-                let fadt_mapping =
-                    unsafe { self.handler.map_physical_region::<Fadt>(physical_address, mem::size_of::<Fadt>()) };
-                fadt_mapping.validate()?;
-
-                let dsdt_address = fadt_mapping.dsdt_address()?;
-                let dsdt_header = sdt::peek_at_sdt_header(&self.handler, dsdt_address);
-                self.dsdt = Some(AmlTable::new(dsdt_address, dsdt_header.length));
-
-                /*
-                 * We've already validated the FADT to get the DSDT out, so it doesn't need to be done again.
-                 */
-                self.sdts
-                    .insert(Signature::FADT, Sdt { physical_address, length: header.length, validated: true });
-            }
-            Signature::SSDT => {
-                self.ssdts.push(AmlTable::new(physical_address, header.length));
-            }
-            signature => {
-                self.sdts.insert(signature, Sdt { physical_address, length: header.length, validated: false });
-            }
+        SsdtIterator {
+            cur_address: table_base_address,
+            end_address: table_end_address,
+            handler: self.handler.clone(),
+            marker: core::marker::PhantomData,
         }
-
-        Ok(())
-    }
-
-    /// Create a mapping to a SDT, given its signature. This validates the SDT if it has not already been
-    /// validated.
-    ///
-    /// ### Safety
-    /// The table's memory is naively interpreted as a `T`, and so you must be careful in providing a type that
-    /// correctly represents the table's structure. Regardless of the provided type's size, the region mapped will
-    /// be the size specified in the SDT's header. Providing a `T` that is larger than this, *may* lead to
-    /// page-faults, aliasing references, or derefencing uninitialized memory (the latter two of which are UB).
-    /// This isn't forbidden, however, because some tables rely on `T` being larger than a provided SDT in some
-    /// versions of ACPI (the [`ExtendedField`](crate::sdt::ExtendedField) type will be useful if you need to do
-    /// this. See our [`Fadt`](crate::fadt::Fadt) type for an example of this).
-    pub unsafe fn get_sdt<T>(&self, signature: sdt::Signature) -> Result<Option<PhysicalMapping<H, T>>, AcpiError>
-    where
-        T: AcpiTable,
-    {
-        let sdt = match self.sdts.get(&signature) {
-            Some(sdt) => sdt,
-            None => return Ok(None),
-        };
-        let mapping = unsafe { self.handler.map_physical_region::<T>(sdt.physical_address, sdt.length as usize) };
-
-        if !sdt.validated {
-            mapping.header().validate(signature)?;
-        }
-
-        Ok(Some(mapping))
     }
 
     /// Convenience method for contructing a [`PlatformInfo`](crate::platform::PlatformInfo). This is one of the
     /// first things you should usually do with an `AcpiTables`, and allows to collect helpful information about
     /// the platform from the ACPI tables.
-    pub fn platform_info(&self) -> Result<PlatformInfo, AcpiError> {
-        PlatformInfo::new(self)
+    #[cfg(feature = "allocator_api")]
+    pub fn platform_info_in<'a, A>(&'a self, allocator: &'a A) -> AcpiResult<PlatformInfo<A>>
+    where
+        A: core::alloc::Allocator,
+    {
+        PlatformInfo::new_in(self, allocator)
     }
 }
 
@@ -290,11 +293,6 @@ pub struct Sdt {
     pub length: u32,
     /// Whether this SDT has been validated. This is set to `true` the first time it is mapped and validated.
     pub validated: bool,
-}
-
-/// All types representing ACPI tables should implement this trait.
-pub trait AcpiTable {
-    fn header(&self) -> &sdt::SdtHeader;
 }
 
 #[derive(Debug)]
@@ -311,6 +309,95 @@ impl AmlTable {
         AmlTable {
             address: address + mem::size_of::<SdtHeader>(),
             length: length - mem::size_of::<SdtHeader>() as u32,
+        }
+    }
+}
+
+/// ### Safety: Caller must ensure the provided address is valid for being read as an `SdtHeader`.
+unsafe fn read_table<H: AcpiHandler, T: AcpiTable>(
+    handler: H,
+    address: usize,
+) -> AcpiResult<PhysicalMapping<H, T>> {
+    // Attempt to peek at the SDT header to correctly enumerate the entire table.
+    // ### Safety: `address` needs to be valid for the size of `SdtHeader`, or the ACPI tables are malformed (not a software issue).
+    let mapping = unsafe { handler.map_physical_region::<SdtHeader>(address, core::mem::size_of::<SdtHeader>()) };
+    mapping.validate(T::SIGNATURE)?;
+
+    // If possible (if the existing mapping covers enough memory), resuse the existing physical mapping.
+    // This allows allocators/memory managers that map in chunks larger than `size_of::<SdtHeader>()` to be used more efficiently.
+    if mapping.mapped_length() >= (mapping.length as usize) {
+        // ### Safety: Pointer is known non-null.
+        let virtual_start =
+            unsafe { core::ptr::NonNull::new_unchecked(mapping.virtual_start().as_ptr() as *mut _) };
+
+        // ### Safety: Mapping is known-good and validated.
+        Ok(unsafe {
+            PhysicalMapping::new(
+                mapping.physical_start(),
+                virtual_start,
+                mapping.region_length(),
+                mapping.mapped_length(),
+                handler.clone(),
+            )
+        })
+    } else {
+        let sdt_length = mapping.length;
+        // Drop the old mapping here, to ensure it's unmapped in software before requesting an overlapping mapping.
+        drop(mapping);
+
+        // ### Safety: Address and length are already known-good.
+        Ok(unsafe { handler.map_physical_region(address, sdt_length as usize) })
+    }
+}
+
+/// Iterator that steps through all of the tables, and returns only the SSDTs as `AmlTable`s.
+pub struct SsdtIterator<'a, H>
+where
+    H: AcpiHandler,
+{
+    cur_address: usize,
+    end_address: usize,
+    handler: H,
+    marker: core::marker::PhantomData<&'a ()>,
+}
+
+impl<'a, H> Iterator for SsdtIterator<'a, H>
+where
+    H: AcpiHandler,
+{
+    type Item = AmlTable;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        struct Ssdt;
+        // ### Safety: Implementation properly represents a valid SSDT.
+        unsafe impl AcpiTable for Ssdt {
+            const SIGNATURE: Signature = Signature::SSDT;
+
+            fn header(&self) -> &sdt::SdtHeader {
+                // ### Safety: DSDT will always be valid for an SdtHeader at its `self` pointer.
+                unsafe { &*(self as *const Self as *const sdt::SdtHeader) }
+            }
+        }
+
+        if self.cur_address < self.end_address {
+            loop {
+                // Attempt to peek at the SDT header to correctly enumerate the entire table.
+                // ### Safety: `address` needs to be valid for the size of `SdtHeader`, or the ACPI tables are malformed (not a software issue).
+                let sdt_header = unsafe {
+                    self.handler
+                        .map_physical_region::<SdtHeader>(self.cur_address, core::mem::size_of::<SdtHeader>())
+                };
+
+                self.cur_address += sdt_header.length as usize;
+
+                if sdt_header.validate(Ssdt::SIGNATURE).is_err() {
+                    continue;
+                } else {
+                    return Some(AmlTable { address: sdt_header.physical_start(), length: sdt_header.length });
+                }
+            }
+        } else {
+            None
         }
     }
 }

--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -1,28 +1,18 @@
 use crate::{
-    platform::{
-        interrupt::{
-            Apic,
-            InterruptModel,
-            InterruptSourceOverride,
-            IoApic,
-            LocalInterruptLine,
-            NmiLine,
-            NmiProcessor,
-            NmiSource,
-            Polarity,
-            TriggerMode,
-        },
-        Processor,
-        ProcessorInfo,
-        ProcessorState,
-    },
-    sdt::SdtHeader,
-    AcpiError,
+    sdt::{SdtHeader, Signature},
     AcpiTable,
 };
-use alloc::vec::Vec;
 use bit_field::BitField;
 use core::{marker::PhantomData, mem};
+
+#[cfg(feature = "allocator_api")]
+use crate::{
+    platform::{
+        interrupt::{InterruptModel, Polarity, TriggerMode},
+        ProcessorInfo,
+    },
+    AcpiResult,
+};
 
 #[derive(Debug)]
 pub enum MadtError {
@@ -49,14 +39,24 @@ pub struct Madt {
     flags: u32,
 }
 
-impl AcpiTable for Madt {
+/// ### Safety: Implementation properly represents a valid MADT.
+unsafe impl AcpiTable for Madt {
+    const SIGNATURE: Signature = Signature::MADT;
+
     fn header(&self) -> &SdtHeader {
         &self.header
     }
 }
 
 impl Madt {
-    pub fn parse_interrupt_model(&self) -> Result<(InterruptModel, Option<ProcessorInfo>), AcpiError> {
+    #[cfg(feature = "allocator_api")]
+    pub fn parse_interrupt_model_in<'a, A>(
+        &self,
+        allocator: &'a A,
+    ) -> AcpiResult<(InterruptModel<'a, A>, Option<ProcessorInfo<'a, A>>)>
+    where
+        A: core::alloc::Allocator,
+    {
         /*
          * We first do a pass through the MADT to determine which interrupt model is being used.
          */
@@ -70,7 +70,7 @@ impl Madt {
                 MadtEntry::LocalApicNmi(_) |
                 MadtEntry::X2ApicNmi(_) |
                 MadtEntry::LocalApicAddressOverride(_) => {
-                    return self.parse_apic_model();
+                    return self.parse_apic_model_in(allocator);
                 }
 
                 MadtEntry::IoSapic(_) |
@@ -94,7 +94,31 @@ impl Madt {
         Ok((InterruptModel::Unknown, None))
     }
 
-    fn parse_apic_model(&self) -> Result<(InterruptModel, Option<ProcessorInfo>), AcpiError> {
+    #[cfg(feature = "allocator_api")]
+    fn parse_apic_model_in<'a, A>(
+        &self,
+        allocator: &'a A,
+    ) -> AcpiResult<(InterruptModel<'a, A>, Option<ProcessorInfo<'a, A>>)>
+    where
+        A: core::alloc::Allocator,
+    {
+        use crate::{
+            platform::{
+                interrupt::{
+                    Apic,
+                    InterruptSourceOverride,
+                    IoApic,
+                    LocalInterruptLine,
+                    NmiLine,
+                    NmiProcessor,
+                    NmiSource,
+                },
+                Processor,
+                ProcessorState,
+            },
+            AcpiError,
+        };
+
         let mut local_apic_address = self.local_apic_address as u64;
         let mut io_apic_count = 0;
         let mut iso_count = 0;
@@ -114,12 +138,19 @@ impl Madt {
             }
         }
 
-        let mut io_apics = Vec::with_capacity(io_apic_count);
-        let mut interrupt_source_overrides = Vec::with_capacity(iso_count);
-        let mut nmi_sources = Vec::with_capacity(nmi_source_count);
-        let mut local_apic_nmi_lines = Vec::with_capacity(local_nmi_line_count);
+        let mut io_apics = crate::ManagedSlice::new_in(io_apic_count, allocator)?;
+        let mut interrupt_source_overrides = crate::ManagedSlice::new_in(iso_count, allocator)?;
+        let mut nmi_sources = crate::ManagedSlice::new_in(nmi_source_count, allocator)?;
+        let mut local_apic_nmi_lines = crate::ManagedSlice::new_in(local_nmi_line_count, allocator)?;
+        let mut application_processors =
+            crate::ManagedSlice::new_in(processor_count.saturating_sub(1), allocator)?; // Subtract one for the BSP
         let mut boot_processor = None;
-        let mut application_processors = Vec::with_capacity(processor_count.saturating_sub(1)); // Subtract one for the BSP
+
+        io_apic_count = 0;
+        iso_count = 0;
+        nmi_source_count = 0;
+        local_nmi_line_count = 0;
+        processor_count = 0;
 
         for entry in self.entries() {
             match entry {
@@ -145,7 +176,8 @@ impl Madt {
                     };
 
                     if is_ap {
-                        application_processors.push(processor);
+                        application_processors[processor_count] = processor;
+                        processor_count += 1;
                     } else {
                         boot_processor = Some(processor);
                     }
@@ -160,7 +192,6 @@ impl Madt {
                         (true, false) => ProcessorState::WaitingForSipi,
                         (false, false) => ProcessorState::Running,
                     };
-                    log::info!("Found X2APIC in MADT!");
 
                     let processor = Processor {
                         processor_uid: entry.processor_uid,
@@ -170,18 +201,20 @@ impl Madt {
                     };
 
                     if is_ap {
-                        application_processors.push(processor);
+                        application_processors[processor_count] = processor;
+                        processor_count += 1;
                     } else {
                         boot_processor = Some(processor);
                     }
                 }
 
                 MadtEntry::IoApic(entry) => {
-                    io_apics.push(IoApic {
+                    io_apics[io_apic_count] = IoApic {
                         id: entry.io_apic_id,
                         address: entry.io_apic_address,
                         global_system_interrupt_base: entry.global_system_interrupt_base,
-                    });
+                    };
+                    io_apic_count += 1;
                 }
 
                 MadtEntry::InterruptSourceOverride(entry) => {
@@ -191,49 +224,57 @@ impl Madt {
 
                     let (polarity, trigger_mode) = parse_mps_inti_flags(entry.flags)?;
 
-                    interrupt_source_overrides.push(InterruptSourceOverride {
+                    interrupt_source_overrides[iso_count] = InterruptSourceOverride {
                         isa_source: entry.irq,
                         global_system_interrupt: entry.global_system_interrupt,
                         polarity,
                         trigger_mode,
-                    });
+                    };
+                    iso_count += 1;
                 }
 
                 MadtEntry::NmiSource(entry) => {
                     let (polarity, trigger_mode) = parse_mps_inti_flags(entry.flags)?;
 
-                    nmi_sources.push(NmiSource {
+                    nmi_sources[nmi_source_count] = NmiSource {
                         global_system_interrupt: entry.global_system_interrupt,
                         polarity,
                         trigger_mode,
-                    });
+                    };
+                    nmi_source_count += 1;
                 }
 
-                MadtEntry::LocalApicNmi(entry) => local_apic_nmi_lines.push(NmiLine {
-                    processor: if entry.processor_id == 0xff {
-                        NmiProcessor::All
-                    } else {
-                        NmiProcessor::ProcessorUid(entry.processor_id as u32)
-                    },
-                    line: match entry.nmi_line {
-                        0 => LocalInterruptLine::Lint0,
-                        1 => LocalInterruptLine::Lint1,
-                        _ => return Err(AcpiError::InvalidMadt(MadtError::InvalidLocalNmiLine)),
-                    },
-                }),
+                MadtEntry::LocalApicNmi(entry) => {
+                    local_apic_nmi_lines[local_nmi_line_count] = NmiLine {
+                        processor: if entry.processor_id == 0xff {
+                            NmiProcessor::All
+                        } else {
+                            NmiProcessor::ProcessorUid(entry.processor_id as u32)
+                        },
+                        line: match entry.nmi_line {
+                            0 => LocalInterruptLine::Lint0,
+                            1 => LocalInterruptLine::Lint1,
+                            _ => return Err(AcpiError::InvalidMadt(MadtError::InvalidLocalNmiLine)),
+                        },
+                    };
+                    local_nmi_line_count += 1;
+                }
 
-                MadtEntry::X2ApicNmi(entry) => local_apic_nmi_lines.push(NmiLine {
-                    processor: if entry.processor_uid == 0xffffffff {
-                        NmiProcessor::All
-                    } else {
-                        NmiProcessor::ProcessorUid(entry.processor_uid)
-                    },
-                    line: match entry.nmi_line {
-                        0 => LocalInterruptLine::Lint0,
-                        1 => LocalInterruptLine::Lint1,
-                        _ => return Err(AcpiError::InvalidMadt(MadtError::InvalidLocalNmiLine)),
-                    },
-                }),
+                MadtEntry::X2ApicNmi(entry) => {
+                    local_apic_nmi_lines[local_nmi_line_count] = NmiLine {
+                        processor: if entry.processor_uid == 0xffffffff {
+                            NmiProcessor::All
+                        } else {
+                            NmiProcessor::ProcessorUid(entry.processor_uid)
+                        },
+                        line: match entry.nmi_line {
+                            0 => LocalInterruptLine::Lint0,
+                            1 => LocalInterruptLine::Lint1,
+                            _ => return Err(AcpiError::InvalidMadt(MadtError::InvalidLocalNmiLine)),
+                        },
+                    };
+                    local_nmi_line_count += 1;
+                }
 
                 MadtEntry::LocalApicAddressOverride(entry) => {
                     local_apic_address = entry.local_apic_address;
@@ -246,15 +287,15 @@ impl Madt {
         }
 
         Ok((
-            InterruptModel::Apic(Apic {
+            InterruptModel::Apic(Apic::new(
                 local_apic_address,
                 io_apics,
                 local_apic_nmi_lines,
                 interrupt_source_overrides,
                 nmi_sources,
-                also_has_legacy_pics: self.supports_8259(),
-            }),
-            Some(ProcessorInfo { boot_processor: boot_processor.unwrap(), application_processors }),
+                self.supports_8259(),
+            )),
+            Some(ProcessorInfo::new(boot_processor.unwrap(), application_processors)),
         ))
     }
 
@@ -371,14 +412,14 @@ impl<'a> Iterator for MadtEntryIter<'a> {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct EntryHeader {
     entry_type: u8,
     length: u8,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct LocalApicEntry {
     header: EntryHeader,
@@ -387,7 +428,7 @@ pub struct LocalApicEntry {
     flags: u32,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct IoApicEntry {
     header: EntryHeader,
@@ -397,7 +438,7 @@ pub struct IoApicEntry {
     global_system_interrupt_base: u32,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct InterruptSourceOverrideEntry {
     header: EntryHeader,
@@ -407,7 +448,7 @@ pub struct InterruptSourceOverrideEntry {
     flags: u16,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct NmiSourceEntry {
     header: EntryHeader,
@@ -415,7 +456,7 @@ pub struct NmiSourceEntry {
     global_system_interrupt: u32,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct LocalApicNmiEntry {
     header: EntryHeader,
@@ -424,7 +465,7 @@ pub struct LocalApicNmiEntry {
     nmi_line: u8, // Describes which LINTn is the NMI connected to
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct LocalApicAddressOverrideEntry {
     header: EntryHeader,
@@ -434,7 +475,7 @@ pub struct LocalApicAddressOverrideEntry {
 
 /// If this entry is present, the system has an I/O SAPIC, which must be used instead of the I/O
 /// APIC.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct IoSapicEntry {
     header: EntryHeader,
@@ -444,7 +485,7 @@ pub struct IoSapicEntry {
     io_sapic_address: u64,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct LocalSapicEntry {
     header: EntryHeader,
@@ -462,7 +503,7 @@ pub struct LocalSapicEntry {
     processor_uid_string: u8,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct PlatformInterruptSourceEntry {
     header: EntryHeader,
@@ -475,7 +516,7 @@ pub struct PlatformInterruptSourceEntry {
     platform_interrupt_source_flags: u32,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct LocalX2ApicEntry {
     header: EntryHeader,
@@ -485,7 +526,7 @@ pub struct LocalX2ApicEntry {
     processor_uid: u32,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct X2ApicNmiEntry {
     header: EntryHeader,
@@ -498,7 +539,7 @@ pub struct X2ApicNmiEntry {
 /// This field will appear for ARM processors that support ACPI and use the Generic Interrupt
 /// Controller. In the GICC interrupt model, each logical process has a Processor Device object in
 /// the namespace, and uses this structure to convey its GIC information.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct GiccEntry {
     header: EntryHeader,
@@ -518,7 +559,7 @@ pub struct GiccEntry {
     _reserved2: [u8; 3],
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct GicdEntry {
     header: EntryHeader,
@@ -538,7 +579,7 @@ pub struct GicdEntry {
     _reserved2: [u8; 3],
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct GicMsiFrameEntry {
     header: EntryHeader,
@@ -550,7 +591,7 @@ pub struct GicMsiFrameEntry {
     spi_base: u16,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct GicRedistributorEntry {
     header: EntryHeader,
@@ -559,7 +600,7 @@ pub struct GicRedistributorEntry {
     discovery_range_length: u32,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct GicInterruptTranslationServiceEntry {
     header: EntryHeader,
@@ -569,7 +610,7 @@ pub struct GicInterruptTranslationServiceEntry {
     _reserved2: u32,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct MultiprocessorWakeupEntry {
     header: EntryHeader,
@@ -578,19 +619,20 @@ pub struct MultiprocessorWakeupEntry {
     mailbox_address: u64,
 }
 
-fn parse_mps_inti_flags(flags: u16) -> Result<(Polarity, TriggerMode), AcpiError> {
+#[cfg(feature = "allocator_api")]
+fn parse_mps_inti_flags(flags: u16) -> crate::AcpiResult<(Polarity, TriggerMode)> {
     let polarity = match flags.get_bits(0..2) {
         0b00 => Polarity::SameAsBus,
         0b01 => Polarity::ActiveHigh,
         0b11 => Polarity::ActiveLow,
-        _ => return Err(AcpiError::InvalidMadt(MadtError::MpsIntiInvalidPolarity)),
+        _ => return Err(crate::AcpiError::InvalidMadt(MadtError::MpsIntiInvalidPolarity)),
     };
 
     let trigger_mode = match flags.get_bits(2..4) {
         0b00 => TriggerMode::SameAsBus,
         0b01 => TriggerMode::Edge,
         0b11 => TriggerMode::Level,
-        _ => return Err(AcpiError::InvalidMadt(MadtError::MpsIntiInvalidTriggerMode)),
+        _ => return Err(crate::AcpiError::InvalidMadt(MadtError::MpsIntiInvalidTriggerMode)),
     };
 
     Ok((polarity, trigger_mode))

--- a/acpi/src/managed_slice.rs
+++ b/acpi/src/managed_slice.rs
@@ -1,0 +1,65 @@
+use core::{alloc, mem};
+
+/// Thin wrapper around a regular slice, taking a reference to an allocator for automatic
+/// deallocation when the slice is dropped out of scope.
+#[derive(Debug)]
+pub struct ManagedSlice<'a, T, A>
+where
+    A: alloc::Allocator,
+{
+    slice: &'a mut [T],
+    allocator: &'a A,
+}
+
+impl<'a, T, A> ManagedSlice<'a, T, A>
+where
+    A: alloc::Allocator,
+{
+    /// Attempts to allocate a new `&mut [T]` in the given allocator.
+    pub fn new_in(len: usize, allocator: &'a A) -> crate::AcpiResult<Self> {
+        // ### Safety: Struct layouts are required to be valid.
+        let layout =
+            unsafe { alloc::Layout::from_size_align_unchecked(mem::size_of::<T>() * len, mem::align_of::<T>()) };
+
+        unsafe { allocator.allocate(layout).map(|ptr| ptr.as_uninit_slice_mut().align_to_mut::<T>().1) }
+            .map(|slice| Self { slice, allocator })
+            .map_err(|_| crate::AcpiError::AllocError)
+    }
+}
+
+impl<'a, T, A> Drop for ManagedSlice<'a, T, A>
+where
+    A: alloc::Allocator,
+{
+    fn drop(&mut self) {
+        // ### Safety: Slice is required by function to point to non-null memory.
+        let slice_ptr = unsafe { core::ptr::NonNull::new_unchecked(self.slice.as_ptr().cast_mut().cast::<u8>()) };
+        // ### Safety: Slice is constructed from a valid layout.
+        let slice_layout = unsafe {
+            alloc::Layout::from_size_align_unchecked(mem::size_of_val(self.slice), mem::align_of_val(self.slice))
+        };
+
+        // ### Safety: Caller is required to provide a slice allocated with the provided allocator.
+        unsafe { self.allocator.deallocate(slice_ptr, slice_layout) };
+    }
+}
+
+impl<'a, T, A> core::ops::Deref for ManagedSlice<'a, T, A>
+where
+    A: alloc::Allocator,
+{
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.slice
+    }
+}
+
+impl<'a, T, A> core::ops::DerefMut for ManagedSlice<'a, T, A>
+where
+    A: alloc::Allocator,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.slice
+    }
+}

--- a/acpi/src/platform/interrupt.rs
+++ b/acpi/src/platform/interrupt.rs
@@ -1,4 +1,5 @@
-use alloc::vec::Vec;
+use crate::ManagedSlice;
+use core::alloc::Allocator;
 
 #[derive(Debug)]
 pub struct IoApic {
@@ -76,12 +77,15 @@ pub struct NmiSource {
 }
 
 #[derive(Debug)]
-pub struct Apic {
+pub struct Apic<'a, A>
+where
+    A: Allocator,
+{
     pub local_apic_address: u64,
-    pub io_apics: Vec<IoApic>,
-    pub local_apic_nmi_lines: Vec<NmiLine>,
-    pub interrupt_source_overrides: Vec<InterruptSourceOverride>,
-    pub nmi_sources: Vec<NmiSource>,
+    pub io_apics: ManagedSlice<'a, IoApic, A>,
+    pub local_apic_nmi_lines: ManagedSlice<'a, NmiLine, A>,
+    pub interrupt_source_overrides: ManagedSlice<'a, InterruptSourceOverride, A>,
+    pub nmi_sources: ManagedSlice<'a, NmiSource, A>,
 
     /// If this field is set, you must remap and mask all the lines of the legacy PIC, even if
     /// you choose to use the APIC. It's recommended that you do this even if ACPI does not
@@ -89,9 +93,35 @@ pub struct Apic {
     pub also_has_legacy_pics: bool,
 }
 
+impl<'a, A> Apic<'a, A>
+where
+    A: Allocator,
+{
+    pub(crate) fn new(
+        local_apic_address: u64,
+        io_apics: ManagedSlice<'a, IoApic, A>,
+        local_apic_nmi_lines: ManagedSlice<'a, NmiLine, A>,
+        interrupt_source_overrides: ManagedSlice<'a, InterruptSourceOverride, A>,
+        nmi_sources: ManagedSlice<'a, NmiSource, A>,
+        also_has_legacy_pics: bool,
+    ) -> Self {
+        Self {
+            local_apic_address,
+            io_apics,
+            local_apic_nmi_lines,
+            interrupt_source_overrides,
+            nmi_sources,
+            also_has_legacy_pics,
+        }
+    }
+}
+
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum InterruptModel {
+pub enum InterruptModel<'a, A>
+where
+    A: Allocator,
+{
     /// This model is only chosen when the MADT does not describe another interrupt model. On `x86_64` platforms,
     /// this probably means only the legacy i8259 PIC is present.
     Unknown,
@@ -99,5 +129,5 @@ pub enum InterruptModel {
     /// Describes an interrupt controller based around the Advanced Programmable Interrupt Controller (any of APIC,
     /// XAPIC, or X2APIC). These are likely to be found on x86 and x86_64 systems and are made up of a Local APIC
     /// for each core and one or more I/O APICs to handle external interrupts.
-    Apic(Apic),
+    Apic(Apic<'a, A>),
 }

--- a/acpi/src/platform/mod.rs
+++ b/acpi/src/platform/mod.rs
@@ -1,12 +1,19 @@
-pub mod address;
 pub mod interrupt;
 
-use crate::{fadt::Fadt, madt::Madt, AcpiError, AcpiHandler, AcpiTables, PowerProfile};
-use address::GenericAddress;
-use alloc::vec::Vec;
+use crate::{
+    address::GenericAddress,
+    fadt::Fadt,
+    madt::Madt,
+    AcpiError,
+    AcpiHandler,
+    AcpiTables,
+    ManagedSlice,
+    PowerProfile,
+};
+use core::alloc::Allocator;
 use interrupt::InterruptModel;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProcessorState {
     /// A processor in this state is unusable, and you must not attempt to bring it up.
     Disabled,
@@ -19,7 +26,7 @@ pub enum ProcessorState {
     Running,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Processor {
     /// Corresponds to the `_UID` object of the processor's `Device`, or the `ProcessorId` field of the `Processor`
     /// object, in AML.
@@ -38,10 +45,22 @@ pub struct Processor {
 }
 
 #[derive(Debug)]
-pub struct ProcessorInfo {
+pub struct ProcessorInfo<'a, A>
+where
+    A: Allocator,
+{
     pub boot_processor: Processor,
     /// Application processors should be brought up in the order they're defined in this list.
-    pub application_processors: Vec<Processor>,
+    pub application_processors: ManagedSlice<'a, Processor, A>,
+}
+
+impl<'a, A> ProcessorInfo<'a, A>
+where
+    A: Allocator,
+{
+    pub(crate) fn new(boot_processor: Processor, application_processors: ManagedSlice<'a, Processor, A>) -> Self {
+        Self { boot_processor, application_processors }
+    }
 }
 
 /// Information about the ACPI Power Management Timer (ACPI PM Timer).
@@ -66,34 +85,36 @@ impl PmTimer {
 /// tables in a nice way. It requires access to the `FADT` and `MADT`. It is the easiest way to get information
 /// about the processors and interrupt controllers on a platform.
 #[derive(Debug)]
-pub struct PlatformInfo {
+pub struct PlatformInfo<'a, A>
+where
+    A: Allocator,
+{
     pub power_profile: PowerProfile,
-    pub interrupt_model: InterruptModel,
+    pub interrupt_model: InterruptModel<'a, A>,
     /// On `x86_64` platforms that support the APIC, the processor topology must also be inferred from the
     /// interrupt model. That information is stored here, if present.
-    pub processor_info: Option<ProcessorInfo>,
+    pub processor_info: Option<ProcessorInfo<'a, A>>,
     pub pm_timer: Option<PmTimer>,
     /*
      * TODO: we could provide a nice view of the hardware register blocks in the FADT here.
      */
 }
 
-impl PlatformInfo {
-    pub fn new<H>(tables: &AcpiTables<H>) -> Result<PlatformInfo, AcpiError>
+impl<'a, A> PlatformInfo<'a, A>
+where
+    A: Allocator,
+{
+    pub fn new_in<H>(tables: &AcpiTables<H>, allocator: &'a A) -> crate::AcpiResult<Self>
     where
         H: AcpiHandler,
     {
-        let fadt = unsafe {
-            tables
-                .get_sdt::<Fadt>(crate::sdt::Signature::FADT)?
-                .ok_or(AcpiError::TableMissing(crate::sdt::Signature::FADT))?
-        };
+        let fadt = tables.find_table::<Fadt>()?;
         let power_profile = fadt.power_profile();
 
-        let madt = unsafe { tables.get_sdt::<Madt>(crate::sdt::Signature::MADT)? };
+        let madt = tables.find_table::<Madt>();
         let (interrupt_model, processor_info) = match madt {
-            Some(madt) => madt.parse_interrupt_model()?,
-            None => (InterruptModel::Unknown, None),
+            Ok(madt) => madt.parse_interrupt_model_in(allocator)?,
+            Err(_) => (InterruptModel::Unknown, None),
         };
         let pm_timer = PmTimer::new(&fadt)?;
 


### PR DESCRIPTION
An overall rework of structures to make the crate allocationless. However, a new feature `allocator_api` has been added in addition to these changes, which allows use of `PlatformInfo` and some other allocating structures, by providing a `core::alloc::Allocator` in the constructor of these types. This allows semantic interfacing with existing allocation APIs, while also ensuring we aren't using the `alloc` crate allocation behaviour by default, as it isn't very extensible for use in bare-metal development contexts.