### PR TITLE
acpi: Improve memory mapping usage

### DIFF
--- a/acpi/Cargo.toml
+++ b/acpi/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 bit_field = "0.10"
+log = "0.4"
 rsdp = { version = "2", path = "../rsdp" }
 
 [features]

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -287,14 +287,17 @@ where
     /// Finds and returns the DSDT AML table, if it exists.
     pub fn dsdt(&self) -> AcpiResult<AmlTable> {
         self.find_table::<fadt::Fadt>().and_then(|fadt| {
-            struct Dsdt;
+            #[repr(transparent)]
+            struct Dsdt {
+                header: SdtHeader,
+            }
+
             // Safety: Implementation properly represents a valid DSDT.
             unsafe impl AcpiTable for Dsdt {
                 const SIGNATURE: Signature = Signature::DSDT;
 
-                fn header(&self) -> &sdt::SdtHeader {
-                    // Safety: DSDT will always be valid for an SdtHeader at its `self` pointer.
-                    unsafe { &*(self as *const Self as *const sdt::SdtHeader) }
+                fn header(&self) -> &SdtHeader {
+                    &self.header
                 }
             }
 


### PR DESCRIPTION
This is a collection of bugfixes and (backwards-compatible) improvements to the `acpi` and `rsdp` crates related to memory mapping. Descriptions of each change is provided in its commit message. Please let me know if I misinterpreted the code I modified or this pull request should be split up!