### PR TITLE
aml: Add DefExternal

### DIFF
--- a/aml/src/expression.rs
+++ b/aml/src/expression.rs
@@ -564,6 +564,7 @@ where
                         // TODO: what to do with this?
                         AmlType::DdbHandle => 0,
                         AmlType::ObjReference => todo!(),
+                        AmlType::External => unimplemented!(),
                     };
 
                     (Ok(AmlValue::Integer(typ)), context)

--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -285,6 +285,7 @@ impl AmlContext {
             LevelType::PowerResource => Ok(false),
             LevelType::ThermalZone => Ok(false),
             LevelType::MethodLocals => Ok(false),
+            LevelType::External => Ok(false),
         })?;
 
         Ok(())
@@ -707,6 +708,7 @@ pub enum AmlError {
     InvalidNameSeg,
     InvalidPkgLength,
     InvalidFieldFlags,
+    InvalidObjectType(u8),
     UnterminatedStringConstant,
     InvalidStringConstant,
     InvalidRegionSpace(u8),

--- a/aml/src/namespace.rs
+++ b/aml/src/namespace.rs
@@ -37,6 +37,8 @@ pub enum LevelType {
     /// A level of this type is created at the same path as the name of a method when it is invoked. It can be
     /// used by the method to store local variables.
     MethodLocals,
+    /// A level that is declared as an External object
+    External,
 }
 
 #[derive(Clone, Debug)]
@@ -96,19 +98,41 @@ impl Namespace {
          * try and recreate the root scope. Instead of handling this specially in the parser, we just
          * return nicely here.
          */
-        if path != AmlName::root() {
-            let (level, last_seg) = self.get_level_for_path_mut(&path)?;
-
-            /*
-             * If the level has already been added, we don't need to add it again. The parser can try to add it
-             * multiple times if the ASL contains multiple blocks that add to the same scope/device.
-             */
-            if !level.children.contains_key(&last_seg) {
-                level.children.insert(last_seg, NamespaceLevel::new(typ));
-            }
+        if path == AmlName::root() {
+            return Ok(());
         }
 
-        Ok(())
+        let (level, last_seg) = self.get_level_for_path_mut(&path)?;
+
+        match level.children.get_mut(&last_seg) {
+            Some(child) if typ == LevelType::External || typ == LevelType::Scope => {
+                Ok(())
+            }
+            Some(child) if child.typ == LevelType::External || child.typ == LevelType::Scope => {
+                child.typ = typ;
+                Ok(())
+            }
+            Some(child) => {
+                Err(AmlError::NameCollision(path))
+            }
+            None => {
+                level.children.insert(last_seg, NamespaceLevel::new(typ));
+                Ok(())
+            }
+        }
+    }
+
+    /// Add an External level to the namespace. The parent level may not exist, so recursively
+    /// visit parents first and add as needed.
+    /// Expects that add_level with not error when the level exists.
+    pub fn add_external_levels(&mut self, path: AmlName) -> Result<(), AmlError> {
+        assert!(path.is_absolute());
+        if path == AmlName::root() {
+            return Ok(());
+        }
+
+        self.add_external_levels(path.parent()?)?;
+        self.add_level(path, LevelType::External)
     }
 
     pub fn remove_level(&mut self, path: AmlName) -> Result<(), AmlError> {
@@ -134,14 +158,38 @@ impl Namespace {
         assert!(path.is_absolute());
         let path = path.normalize()?;
 
-        let handle = self.next_handle;
-        self.next_handle.increment();
-        self.object_map.insert(handle, value);
-
-        let (level, last_seg) = self.get_level_for_path_mut(&path)?;
-        match level.values.insert(last_seg, handle) {
-            None => Ok(handle),
-            Some(_) => Err(AmlError::NameCollision(path)),
+        // Check if the name already exists in the namespace, and whether it is an External
+        let (level, last_seg) = self.get_level_for_path(&path)?;
+        match level.values.get(&last_seg) {
+            Some(old_handle) if matches!(value, AmlValue::External) => {
+                Ok(old_handle.clone())
+            }
+            Some(old_handle) => {
+                match self.object_map.get(old_handle) {
+                    Some(old_value) if matches!(old_value, AmlValue::External) => {
+                        let handle = old_handle.clone();
+                        let _ = self.object_map.insert(handle, value);
+                        Ok(handle)
+                    }
+                    Some(old_value) => {
+                        Err(AmlError::NameCollision(path))
+                    }
+                    _ => {
+                        Err(AmlError::FatalError)
+                    }
+                }
+            }
+            None => {
+                let handle = self.next_handle;
+                self.next_handle.increment();
+                self.object_map.insert(handle, value);
+                
+                let (level, last_seg) = self.get_level_for_path_mut(&path)?;
+                match level.values.insert(last_seg, handle) {
+                    None => Ok(handle),
+                    Some(_) => Err(AmlError::NameCollision(path)),
+                }
+            }
         }
     }
 

--- a/aml/src/opcode.rs
+++ b/aml/src/opcode.rs
@@ -97,6 +97,31 @@ pub const ARG6_OP: u8 = 0x6e;
 
 pub const EXT_OPCODE_PREFIX: u8 = 0x5b;
 
+/*
+ * Object Types (https://github.com/acpica/acpica/blob/master/source/common/dmextern.c)
+ * Used for DefExternal
+ */
+pub const OBJTYPE_UNKNOWN: u8 = 0x00;
+pub const OBJTYPE_INTEGER: u8 = 0x01;
+pub const OBJTYPE_STRING: u8 = 0x02;
+pub const OBJTYPE_BUFFER: u8 = 0x03;
+pub const OBJTYPE_PACKAGE: u8 = 0x04;
+pub const OBJTYPE_FIELD_UNIT: u8 = 0x05;
+pub const OBJTYPE_DEVICE: u8 = 0x06;
+pub const OBJTYPE_EVENT: u8 = 0x07;
+pub const OBJTYPE_METHOD: u8 = 0x08;
+pub const OBJTYPE_MUTEX: u8 = 0x09;
+pub const OBJTYPE_OP_REGION: u8 = 0x0a;
+pub const OBJTYPE_POWER_RES: u8 = 0x0b;
+pub const OBJTYPE_PROCESSOR: u8 = 0x0c;
+pub const OBJTYPE_THERMAL_ZONE: u8 = 0x0d;
+pub const OBJTYPE_BUFFER_FIELD: u8 = 0x0e;
+pub const OBJTYPE_DDBHANDLE: u8 = 0x0f;
+pub const OBJTYPE_DEBUG_OBJ: u8 = 0x10;
+pub const OBJTYPE_FIELD_UNIT_2: u8 = 0x11;
+pub const OBJTYPE_FIELD_UNIT_3: u8 = 0x12;
+pub const OBJTYPE_FIELD_UNIT_4: u8 = 0x13;
+
 pub(crate) fn opcode<'a, 'c>(opcode: u8) -> impl Parser<'a, 'c, ()>
 where
     'c: 'a,

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -668,23 +668,22 @@ where
                         }
                     };
                     let resolved_name = try_with_context!(context, name.resolve(&context.current_scope));
-                    let parent_name = try_with_context!(context, name.parent());
                     if is_level {
                         try_with_context!(
                             context,
-                            context.namespace.add_external_levels(resolved_name.clone())
+                            context.namespace.add_external_levels(resolved_name)
                         );
                     } else {
+                        let parent_name = try_with_context!(context, resolved_name.parent());
                         try_with_context!(
                             context,
                             context.namespace.add_external_levels(parent_name)
                         );
+                        try_with_context!(
+                            context,
+                            context.namespace.add_value(resolved_name.clone(), AmlValue::External)
+                        );
                     }
-                    try_with_context!(
-                        context,
-                        context.namespace.add_value(resolved_name.clone(), AmlValue::External)
-                    );
-
                     (Ok(()), context)
                 })
                 .then(take())))

--- a/aml/src/test_utils.rs
+++ b/aml/src/test_utils.rs
@@ -211,5 +211,9 @@ pub(crate) fn crudely_cmp_values(a: &AmlValue, b: &AmlValue) -> bool {
             AmlValue::ThermalZone => true,
             _ => false,
         },
+        AmlValue::External => match b {
+            AmlValue::External => true,
+            _ => false,
+        }
     }
 }

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -155,6 +155,7 @@ pub enum AmlType {
     RawDataBuffer,
     String,
     ThermalZone,
+    External,
 }
 
 #[derive(Clone)]
@@ -221,6 +222,7 @@ pub enum AmlValue {
         resource_order: u16,
     },
     ThermalZone,
+    External,
 }
 
 impl AmlValue {
@@ -260,6 +262,7 @@ impl AmlValue {
             AmlValue::Package(_) => AmlType::Package,
             AmlValue::PowerResource { .. } => AmlType::PowerResource,
             AmlValue::ThermalZone => AmlType::ThermalZone,
+            AmlValue::External => AmlType::External,
         }
     }
 
@@ -286,7 +289,7 @@ impl AmlValue {
                 let bytes = bytes.lock();
                 let bytes = if bytes.len() > 8 { &bytes[0..8] } else { &bytes[..] };
 
-                Ok(bytes.iter().rev().fold(0: u64, |mut i, &popped| {
+                Ok(bytes.iter().rev().fold(0u64, |mut i, &popped| {
                     i <<= 8;
                     i += popped as u64;
                     i
@@ -347,6 +350,7 @@ impl AmlValue {
             AmlType::PowerResource => AmlValue::String("[Power Resource]".to_string()),
             AmlType::RawDataBuffer => AmlValue::String("[Raw Data Buffer]".to_string()),
             AmlType::ThermalZone => AmlValue::String("[Thermal Zone]".to_string()),
+            AmlType::External => AmlValue::String("[External]".to_string()),
         }
     }
 


### PR DESCRIPTION
Implement DefExternal, with If(0) guard
- Externals are in an If(0) block. See acpica/documents/changes.txt, Summary of changes for version 20160212.
- Because Externals are in an If(0) block, a special case of `def_if_else` checks for If(predicate == false) with no Else. It doesn't check for If(0) specifically, as the details of the predicate are not available when the check is done. This special-case code calls a new parser function, `externals_list`, on the `then_branch`.
- `externals_list` takes a list_length, and operates similar to `term_list`. It accepts any number of Externals, but if it gets something other than External, it just does `take_to_end_of_pkglength` and discards the result. This should allow it to still handle the case where `If(false)` occurs in other situations, as it will just skip the content as it did previously. However, the case that Externals are mixed with other statements will not be processed completely. I don't know if this occurs in real-world examples.
- `def_external` adds values and levels to the namespace. It considers the ObjectType when deciding if it should add it as a level.
- ObjectTypes for External declarations are taken from acpica source because it is more accurate than the spec.
- Levels added are `LevelType::External`. Values added are `AmlType::External`.
- Attempts to convert External to Integer, etc. will fail, as the value is not known. I'm not sure how to order the processing of tables to ensure actual definitions occur before attempts to read Externals.
- New function `add_external_levels` optionally adds all parent levels when defining an External symbol. This is necessary because of real-world AML e.g. a table with this as the first declaration: `External (_SB_.PR00._CST, UnknownObj)`
- Name collision handling now checks for the following situations:
  - add_value External when value exists - return the old handle
  - add_value other than External when External exists - replace the value at the old handle and return the old handle
  - add_value other than External when value exists - NameCollision error
  - add_level External or Scope when level exists - no change
  - add_level not External or Scope when level was External or Scope - update level.typ
  - add_level not External or Scope when level was not External or Scope - NameCollision error
- Added tests for the above
