### PR TITLE
Add stub implementations for Handler, read_u16 etc.

### DIFF
--- a/aml_tester/src/main.rs
+++ b/aml_tester/src/main.rs
@@ -151,68 +151,79 @@ impl log::Log for Logger {
 struct Handler;
 
 impl aml::Handler for Handler {
-    fn read_u8(&self, _address: usize) -> u8 {
-        unimplemented!()
+    fn read_u8(&self, address: usize) -> u8 {
+        println!("read_u8 {address:#x}");
+        0
     }
-    fn read_u16(&self, _address: usize) -> u16 {
-        unimplemented!()
+    fn read_u16(&self, address: usize) -> u16 {
+        println!("read_u16 {address:#x}");
+        0
     }
-    fn read_u32(&self, _address: usize) -> u32 {
-        unimplemented!()
+    fn read_u32(&self, address: usize) -> u32 {
+        println!("read_u32 {address:#x}");
+        0
     }
-    fn read_u64(&self, _address: usize) -> u64 {
-        unimplemented!()
-    }
-
-    fn write_u8(&mut self, _address: usize, _value: u8) {
-        unimplemented!()
-    }
-    fn write_u16(&mut self, _address: usize, _value: u16) {
-        unimplemented!()
-    }
-    fn write_u32(&mut self, _address: usize, _value: u32) {
-        unimplemented!()
-    }
-    fn write_u64(&mut self, _address: usize, _value: u64) {
-        unimplemented!()
+    fn read_u64(&self, address: usize) -> u64 {
+        println!("read_u64 {address:#x}");
+        0
     }
 
-    fn read_io_u8(&self, _port: u16) -> u8 {
-        unimplemented!()
+    fn write_u8(&mut self, address: usize, value: u8) {
+        println!("write_u8 {address:#x}<-{value:#x}");
     }
-    fn read_io_u16(&self, _port: u16) -> u16 {
-        unimplemented!()
+    fn write_u16(&mut self, address: usize, value: u16) {
+        println!("write_u16 {address:#x}<-{value:#x}");
     }
-    fn read_io_u32(&self, _port: u16) -> u32 {
-        unimplemented!()
+    fn write_u32(&mut self, address: usize, value: u32) {
+        println!("write_u32 {address:#x}<-{value:#x}");
     }
-
-    fn write_io_u8(&self, _port: u16, _value: u8) {
-        unimplemented!()
-    }
-    fn write_io_u16(&self, _port: u16, _value: u16) {
-        unimplemented!()
-    }
-    fn write_io_u32(&self, _port: u16, _value: u32) {
-        unimplemented!()
+    fn write_u64(&mut self, address: usize, value: u64) {
+        println!("write_u64 {address:#x}<-{value:#x}");
     }
 
-    fn read_pci_u8(&self, _segment: u16, _bus: u8, _device: u8, _function: u8, _offset: u16) -> u8 {
-        unimplemented!()
+    fn read_io_u8(&self, port: u16) -> u8 {
+        println!("read_io_u8 {port:#x}");
+        0
     }
-    fn read_pci_u16(&self, _segment: u16, _bus: u8, _device: u8, _function: u8, _offset: u16) -> u16 {
-        unimplemented!()
+    fn read_io_u16(&self, port: u16) -> u16 {
+        println!("read_io_u16 {port:#x}");
+        0
     }
-    fn read_pci_u32(&self, _segment: u16, _bus: u8, _device: u8, _function: u8, _offset: u16) -> u32 {
-        unimplemented!()
+    fn read_io_u32(&self, port: u16) -> u32 {
+        println!("read_io_u32 {port:#x}");
+        0
     }
-    fn write_pci_u8(&self, _segment: u16, _bus: u8, _device: u8, _function: u8, _offset: u16, _value: u8) {
-        unimplemented!()
+
+    fn write_io_u8(&self, port: u16, value: u8) {
+        println!("write_io_u8 {port:#x}<-{value:#x}");
     }
-    fn write_pci_u16(&self, _segment: u16, _bus: u8, _device: u8, _function: u8, _offset: u16, _value: u16) {
-        unimplemented!()
+    fn write_io_u16(&self, port: u16, value: u16) {
+        println!("write_io_u16 {port:#x}<-{value:#x}");
     }
-    fn write_pci_u32(&self, _segment: u16, _bus: u8, _device: u8, _function: u8, _offset: u16, _value: u32) {
-        unimplemented!()
+    fn write_io_u32(&self, port: u16, value: u32) {
+        println!("write_io_u32 {port:#x}<-{value:#x}");
+    }
+
+    fn read_pci_u8(&self, segment: u16, bus: u8, device: u8, function: u8, _offset: u16) -> u8 {
+        println!("read_pci_u8 ({segment:#x}, {bus:#x}, {device:#x}, {function:#x})");
+        0
+    }
+    fn read_pci_u16(&self, segment: u16, bus: u8, device: u8, function: u8, _offset: u16) -> u16 {
+        println!("read_pci_u16 ({segment:#x}, {bus:#x}, {device:#x}, {function:#x})");
+        0
+    }
+    fn read_pci_u32(&self, segment: u16, bus: u8, device: u8, function: u8, _offset: u16) -> u32 {
+        println!("read_pci_32 ({segment:#x}, {bus:#x}, {device:#x}, {function:#x})");
+        0
+    }
+
+    fn write_pci_u8(&self, segment: u16, bus: u8, device: u8, function: u8, _offset: u16, value: u8) {
+        println!("write_pci_u8 ({segment:#x}, {bus:#x}, {device:#x}, {function:#x})<-{value:#x}");
+    }
+    fn write_pci_u16(&self, segment: u16, bus: u8, device: u8, function: u8, _offset: u16, value: u16) {
+        println!("write_pci_u16 ({segment:#x}, {bus:#x}, {device:#x}, {function:#x})<-{value:#x}");
+    }
+    fn write_pci_u32(&self, segment: u16, bus: u8, device: u8, function: u8, _offset: u16, value: u32) {
+        println!("write_pci_u32 ({segment:#x}, {bus:#x}, {device:#x}, {function:#x})<-{value:#x}");
     }
 }


### PR DESCRIPTION
read_xx operations print a message and return 0. write_xx operations print a message and do nothing.
Strings are formatted with named parameters due to the number of parameters for PCI operations.