### PR TITLE
Add def_alias, alias shares handle with target

### DIFF
--- a/aml/src/opcode.rs
+++ b/aml/src/opcode.rs
@@ -20,6 +20,7 @@ pub const DWORD_CONST: u8 = 0x0c;
 pub const STRING_PREFIX: u8 = 0x0d;
 pub const QWORD_CONST: u8 = 0x0e;
 
+pub const DEF_ALIAS_OP: u8 = 0x06;
 pub const DEF_NAME_OP: u8 = 0x08;
 pub const DEF_SCOPE_OP: u8 = 0x10;
 pub const DEF_BUFFER_OP: u8 = 0x11;

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -148,7 +148,7 @@ where
     opcode(opcode::DEF_ALIAS_OP)
         .then(comment_scope(
             DebugVerbosity::Scopes,
-            "DefName",
+            "DefAlias",
             name_string().then(name_string()).map_with_context(|(target, alias), context| {
                 try_with_context!(
                     context,

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -77,7 +77,7 @@ where
     /*
      * NamespaceModifierObj := DefAlias | DefName | DefScope
      */
-    choice!(def_name(), def_scope())
+    choice!(def_alias(), def_name(), def_scope())
 }
 
 pub fn named_obj<'a, 'c>() -> impl Parser<'a, 'c, ()>
@@ -130,6 +130,29 @@ where
                 try_with_context!(
                     context,
                     context.namespace.add_value_at_resolved_path(name, &context.current_scope, data_ref_object)
+                );
+                (Ok(()), context)
+            }),
+        ))
+        .discard_result()
+}
+
+pub fn def_alias<'a, 'c>() -> impl Parser<'a, 'c, ()>
+where
+    'c: 'a,
+{
+    /*
+     * DefAlias := 0x06 NameString NameString
+     * The second name refers to the same object as the first
+     */
+    opcode(opcode::DEF_ALIAS_OP)
+        .then(comment_scope(
+            DebugVerbosity::Scopes,
+            "DefName",
+            name_string().then(name_string()).map_with_context(|(target, alias), context| {
+                try_with_context!(
+                    context,
+                    context.namespace.add_alias_at_resolved_path(alias, &context.current_scope, target)
                 );
                 (Ok(()), context)
             }),


### PR DESCRIPTION
`DEF_ALIAS_OP` added (0x06).
This implementation creates a new name in the namespace, but shares the handle with the target name. Any "namespace.get_..." will return the same object for both the alias and the target. The fact that the new name was declared as an alias is forgotten, and the fact that there is more than one name pointing to the same handle is forgotten. Support for an alias of a Scope/Level is not implemented and not checked.