### PR TITLE
Provide a stub version of def_alias, that just discards the alias

### DIFF
--- a/aml/src/opcode.rs
+++ b/aml/src/opcode.rs
@@ -20,6 +20,7 @@ pub const DWORD_CONST: u8 = 0x0c;
 pub const STRING_PREFIX: u8 = 0x0d;
 pub const QWORD_CONST: u8 = 0x0e;
 
+pub const DEF_ALIAS_OP: u8 = 0x06;
 pub const DEF_NAME_OP: u8 = 0x08;
 pub const DEF_SCOPE_OP: u8 = 0x10;
 pub const DEF_BUFFER_OP: u8 = 0x11;

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -77,7 +77,7 @@ where
     /*
      * NamespaceModifierObj := DefAlias | DefName | DefScope
      */
-    choice!(def_name(), def_scope())
+    choice!(def_alias(), def_name(), def_scope())
 }
 
 pub fn named_obj<'a, 'c>() -> impl Parser<'a, 'c, ()>
@@ -113,6 +113,22 @@ where
             def_mutex()
         ),
     )
+}
+
+pub fn def_alias<'a, 'c>() -> impl Parser<'a, 'c, ()>
+where
+    'c: 'a,
+{
+    /*
+     * DefAlias := 0x06 NameString NameString
+     */
+    opcode(opcode::DEF_ALIAS_OP)
+        .then(comment_scope(
+            DebugVerbosity::Scopes,
+            "DefAlias",
+            name_string().then(name_string())
+        ))
+        .discard_result()
 }
 
 pub fn def_name<'a, 'c>() -> impl Parser<'a, 'c, ()>


### PR DESCRIPTION
This is alternative to the other PR that implements `def_alias`. This version just skips the alias definition and does not change the namespace. I need one or the other to be able to move forward with other changes.