### PR TITLE
aml: use invoke_method on _SEG, _BBN, _ADR

### DIFF
--- a/aml/src/expression.rs
+++ b/aml/src/expression.rs
@@ -273,7 +273,7 @@ where
             DebugVerbosity::AllScopes,
             "DefIncrement",
             super_name().map_with_context(|addend, context| {
-                let value = try_with_context!(context, context.read_target(&addend));
+                let value = try_with_context!(context, context.read_target(&addend)).clone();
                 let value = try_with_context!(context, value.as_integer(context));
                 let new_value = AmlValue::Integer(value + 1);
                 try_with_context!(context, context.store(addend, new_value.clone()));
@@ -295,7 +295,7 @@ where
             DebugVerbosity::AllScopes,
             "DefDecrement",
             super_name().map_with_context(|minuend, context| {
-                let value = try_with_context!(context, context.read_target(&minuend));
+                let value = try_with_context!(context, context.read_target(&minuend)).clone();
                 let value = try_with_context!(context, value.as_integer(context));
                 let new_value = AmlValue::Integer(value - 1);
                 try_with_context!(context, context.store(minuend, new_value.clone()));

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -271,7 +271,7 @@ impl AmlValue {
         }
     }
 
-    pub fn as_integer(&self, context: &AmlContext) -> Result<u64, AmlError> {
+    pub fn as_integer(&self, context: &mut AmlContext) -> Result<u64, AmlError> {
         match self {
             AmlValue::Integer(value) => Ok(*value),
             AmlValue::Boolean(value) => Ok(if *value { u64::max_value() } else { 0 }),
@@ -303,7 +303,7 @@ impl AmlValue {
         }
     }
 
-    pub fn as_buffer(&self, context: &AmlContext) -> Result<Arc<Spinlock<Vec<u8>>>, AmlError> {
+    pub fn as_buffer(&self, context: &mut AmlContext) -> Result<Arc<Spinlock<Vec<u8>>>, AmlError> {
         match self {
             AmlValue::Buffer(ref bytes) => Ok(bytes.clone()),
             // TODO: implement conversion of String and Integer to Buffer
@@ -313,7 +313,7 @@ impl AmlValue {
         }
     }
 
-    pub fn as_string(&self, context: &AmlContext) -> Result<String, AmlError> {
+    pub fn as_string(&self, context: &mut AmlContext) -> Result<String, AmlError> {
         match self {
             AmlValue::String(ref string) => Ok(string.clone()),
             // TODO: implement conversion of Buffer to String
@@ -387,7 +387,7 @@ impl AmlValue {
     ///     `Integer` from: `Buffer`, `BufferField`, `DdbHandle`, `FieldUnit`, `String`, `Debug`
     ///     `Package` from: `Debug`
     ///     `String` from: `Integer`, `Buffer`, `Debug`
-    pub fn as_type(&self, desired_type: AmlType, context: &AmlContext) -> Result<AmlValue, AmlError> {
+    pub fn as_type(&self, desired_type: AmlType, context: &mut AmlContext) -> Result<AmlValue, AmlError> {
         // If the value is already of the correct type, just return it as is
         if self.type_of() == desired_type {
             return Ok(self.clone());
@@ -406,7 +406,7 @@ impl AmlValue {
 
     /// Reads from a field of an opregion, returning either a `AmlValue::Integer` or an `AmlValue::Buffer`,
     /// depending on the size of the field.
-    pub fn read_field(&self, context: &AmlContext) -> Result<AmlValue, AmlError> {
+    pub fn read_field(&self, context: &mut AmlContext) -> Result<AmlValue, AmlError> {
         if let AmlValue::Field { region, flags, offset, length } = self {
             let maximum_access_size = {
                 if let AmlValue::OpRegion { region, .. } = context.namespace.get(*region)? {


### PR DESCRIPTION
Use `invoke_method` on special symbols `_SEG`, `_BBN` and `_ADR` as they might be methods. `invoke_method` will just return their value if they are not methods.
Make `read_region` use mutable context. Change clients of `read_region` (`as_integer` etc.) to use mutable context. Clone AmlValue objects before calling `as_integer` etc. to avoid borrow conflicts.