### PR TITLE
acpi: Add missing and new fields to GIC CPU interface structure

### DIFF
--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -1,5 +1,5 @@
 use crate::{
-    sdt::{SdtHeader, Signature},
+    sdt::{ExtendedField, SdtHeader, Signature},
     AcpiTable,
 };
 use bit_field::BitField;
@@ -551,12 +551,19 @@ pub struct GiccEntry {
     performance_interrupt_gsiv: u32,
     parked_address: u64,
     gic_registers_address: u64,
-    gic_control_block_address: u64,
+    gic_virtual_registers_address: u64,
+    gic_hypervisor_registers_address: u64,
     vgic_maintenance_interrupt: u32,
     gicr_base_address: u64,
     mpidr: u64,
     processor_power_efficiency_class: u8,
-    _reserved2: [u8; 3],
+    _reserved2: u8,
+    /// SPE overflow Interrupt.
+    ///
+    /// ACPI 6.3 defined this field. It is zero in prior versions or
+    /// if this processor does not support SPE.
+    spe_overflow_interrupt: u16,
+    trbe_interrupt: ExtendedField<u16, 6>,
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
This adds the previously missing ['GICV'](https://uefi.org/specs/ACPI/6.5/05_ACPI_Software_Programming_Model.html?highlight=GICV#gic-cpu-interface-gicc-structure) field to `GiccEntry` (under the name `gic_virtual_registers_address`, renaming `gic_control_block_address` to `gic_hypervisor_registers_address` to match) and appends the two more recent 'SPE overflow Interrupt' and 'TRBE Interrupt' fields.

A question on appending fields that are introduced in later versions of the specification: Is it reasonable to be concerned about Rust implicitly accessing the new fields on a platform that does not provide them? I don't have an idea of the internals of the compiler, but it seems like the MADT entries might very well end at a page boundary and one risks accessing unmapped memory in the case that any follows. Please let me know if my question is unclear. If this situation is possible, what is the solution? Should the extra fields only be made available through accessor methods that verify the length of the entry, or could a new struct be made for every addition that includes the struct for the previous version of the entry?