### PR TITLE
aml: Add l_and parser and opcode

### DIFF
--- a/aml/src/expression.rs
+++ b/aml/src/expression.rs
@@ -49,6 +49,7 @@ where
             def_l_less(),
             def_l_less_equal(),
             def_l_not_equal(),
+            def_l_and(),
             def_l_or(),
             def_mid(),
             def_object_type(),
@@ -300,6 +301,27 @@ where
                 let new_value = AmlValue::Integer(value - 1);
                 try_with_context!(context, context.store(minuend, new_value.clone()));
                 (Ok(new_value), context)
+            }),
+        ))
+        .map(|((), result)| Ok(result))
+}
+
+fn def_l_and<'a, 'c>() -> impl Parser<'a, 'c, AmlValue>
+where
+    'c: 'a,
+{
+    /*
+     * DefLAnd := 0x90 Operand Operand
+     * Operand := TermArg => Integer
+     */
+    opcode(opcode::DEF_L_AND_OP)
+        .then(comment_scope(
+            DebugVerbosity::AllScopes,
+            "DefLOr",
+            term_arg().then(term_arg()).map_with_context(|(left_arg, right_arg), context| {
+                let left = try_with_context!(context, left_arg.as_bool());
+                let right = try_with_context!(context, right_arg.as_bool());
+                (Ok(AmlValue::Boolean(left && right)), context)
             }),
         ))
         .map(|((), result)| Ok(result))

--- a/aml/src/opcode.rs
+++ b/aml/src/opcode.rs
@@ -68,6 +68,7 @@ pub const DEF_SHIFT_RIGHT: u8 = 0x7a;
 pub const DEF_AND_OP: u8 = 0x7b;
 pub const DEF_CONCAT_RES_OP: u8 = 0x84;
 pub const DEF_OBJECT_TYPE_OP: u8 = 0x8e;
+pub const DEF_L_AND_OP: u8 = 0x90;
 pub const DEF_L_OR_OP: u8 = 0x91;
 pub const DEF_L_NOT_OP: u8 = 0x92;
 pub const DEF_L_EQUAL_OP: u8 = 0x93;


### PR DESCRIPTION
Implemented `def_l_and` based on `def_l_or`. In order to test this on my DSDT, I needed functionality from the "Use `invoke_method`" PR, but I am not including any of that code here. This code has compiles as submitted.