### PR TITLE
acpi: fix length of "extended_area_bytes" in RSDP search

### DIFF
--- a/rsdp/src/lib.rs
+++ b/rsdp/src/lib.rs
@@ -91,15 +91,8 @@ impl Rsdp {
                 handler.map_physical_region::<u8>(area.start, area.end - area.start + RSDP_V2_EXT_LENGTH)
             };
 
-            // SAFETY: The entirety of `mapping` maps the search area and an additional `RSDP_V2_EXT_LENGTH` bytes
-            // that are assumed to be safe to read while `extended_area_bytes` lives. (Ideally, an assumption about
-            // the memory following the search area would not be made.)
-            let extended_area_bytes = unsafe {
-                slice::from_raw_parts(
-                    mapping.virtual_start().as_ptr(),
-                    mapping.region_length() + RSDP_V2_EXT_LENGTH,
-                )
-            };
+            let extended_area_bytes =
+                unsafe { slice::from_raw_parts(mapping.virtual_start().as_ptr(), mapping.region_length()) };
 
             // Search `Rsdp`-sized windows at 16-byte boundaries relative to the base of the area (which is also
             // aligned to 16 bytes due to the implementation of `find_search_areas`)


### PR DESCRIPTION
Since the memory mapping is already including "RSDP_V2_EXT_LENGTH" bytes to allow for an ACPI 1.0 table at the end of the region, it seems that the slice should just use the actual mapping length instead of going beyond it...