### PR TITLE
aml: Do not require unstable features from rustc that are not used

### DIFF
--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -35,7 +35,7 @@
 //! combinator patterns to express the parse.
 
 #![no_std]
-#![feature(decl_macro, type_ascription, box_syntax)]
+#![feature(decl_macro)]
 
 extern crate alloc;
 


### PR DESCRIPTION
The unstable features `type_ascription` and `box_syntax` are not required to compile the `aml` crate. Additionally, `box_syntax` has been removed from rustc, so leaving it in will eventually cause an error.