### PR TITLE
AML: Replace input: &[u8] with AmlStream

### DIFF
--- a/aml/Cargo.toml
+++ b/aml/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 bit_field = "0.10"
+num = "0.4"
 byteorder = { version = "1", default-features = false }
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "atomic"] }
 spinning_top = "0.2.4"

--- a/aml/src/expression.rs
+++ b/aml/src/expression.rs
@@ -143,7 +143,7 @@ where
                     }
 
                     let mut buffer = vec![0; buffer_size];
-                    (&mut buffer[0..bytes.len()]).copy_from_slice(bytes.content());
+                    (&mut buffer[0..bytes.len()]).copy_from_slice(bytes.data());
                     (Ok(buffer), context)
                 })
             }),

--- a/aml/src/expression.rs
+++ b/aml/src/expression.rs
@@ -143,7 +143,7 @@ where
                     }
 
                     let mut buffer = vec![0; buffer_size];
-                    (&mut buffer[0..bytes.len()]).copy_from_slice(bytes);
+                    (&mut buffer[0..bytes.len()]).copy_from_slice(bytes.content());
                     (Ok(buffer), context)
                 })
             }),

--- a/aml/src/opcode.rs
+++ b/aml/src/opcode.rs
@@ -106,7 +106,7 @@ where
 {
     move |input: AmlStream<'a>, context: &'c mut AmlContext| match input.first() {
         None => Err((input, context, Propagate::Err(AmlError::UnexpectedEndOfStream))),
-        Some(&byte) if byte == opcode => Ok((input.slice_to_end(1), context, ())),
+        Some(&byte) if byte == opcode => Ok((input.take_to_end(1), context, ())),
         Some(_) => Err((input, context, Propagate::Err(AmlError::WrongParser))),
     }
 }

--- a/aml/src/parser.rs
+++ b/aml/src/parser.rs
@@ -114,7 +114,7 @@ where
     'c: 'a,
 {
     move |input: AmlStream<'a>, context: &'c mut AmlContext| match input.first() {
-        Some(&byte) => Ok((input.slice_to_end(1), context, byte)),
+        Some(&byte) => Ok((input.take_to_end(1), context, byte)),
         None => Err((input, context, Propagate::Err(AmlError::UnexpectedEndOfStream))),
     }
 }
@@ -128,7 +128,7 @@ where
             return Err((input, context, Propagate::Err(AmlError::UnexpectedEndOfStream)));
         }
 
-        Ok((input.slice_to_end(2), context, input.get_u16(0).unwrap()))
+        Ok((input.take_to_end(2), context, input.get_u16().unwrap()))
     }
 }
 
@@ -141,7 +141,7 @@ where
             return Err((input, context, Propagate::Err(AmlError::UnexpectedEndOfStream)));
         }
 
-        Ok((input.slice_to_end(4), context, input.get_u32(0).unwrap()))
+        Ok((input.take_to_end(4), context, input.get_u32().unwrap()))
     }
 }
 
@@ -154,7 +154,7 @@ where
             return Err((input, context, Propagate::Err(AmlError::UnexpectedEndOfStream)));
         }
 
-        Ok((input.slice_to_end(8), context, input.get_u64(0).unwrap()))
+        Ok((input.take_to_end(8), context, input.get_u64().unwrap()))
     }
 }
 
@@ -241,7 +241,7 @@ where
     F: Fn(u8) -> bool,
 {
     move |input: AmlStream<'a>, context: &'c mut AmlContext| match input.first() {
-        Some(&byte) if condition(byte) => Ok((input.slice_to_end(1), context, byte)),
+        Some(&byte) if condition(byte) => Ok((input.take_to_end(1), context, byte)),
         Some(&byte) => Err((input, context, Propagate::Err(AmlError::UnexpectedByte(byte)))),
         None => Err((input, context, Propagate::Err(AmlError::UnexpectedEndOfStream))),
     }
@@ -289,7 +289,7 @@ where
         let before = input;
         let (after, context, result) = parser.parse(input, context)?;
         let bytes_parsed = before.len() - after.len();
-        let parsed = before.slice_from_start(bytes_parsed);
+        let parsed = before.take_n(bytes_parsed);
 
         Ok((after, context, (result, parsed)))
     }

--- a/aml/src/pkg_length.rs
+++ b/aml/src/pkg_length.rs
@@ -79,7 +79,7 @@ where
                     new_input,
                     context,
                     bytes
-                        .content()
+                        .data()
                         .iter()
                         .enumerate()
                         .fold(initial_length, |length, (i, &byte)| length + (u32::from(byte) << (4 + i * 8))),

--- a/aml/src/statement.rs
+++ b/aml/src/statement.rs
@@ -17,7 +17,7 @@ use crate::{
     term_object::{term_arg, term_list},
     AmlContext,
     AmlError,
-    DebugVerbosity,
+    DebugVerbosity, AmlStream,
 };
 
 pub fn statement_opcode<'a, 'c>() -> impl Parser<'a, 'c, ()>
@@ -141,15 +141,15 @@ where
                             "DefElse",
                             pkg_length().feed(|length| take_to_end_of_pkglength(length))
                         ))
-                        .map(|((), else_branch): ((), &[u8])| Ok(else_branch)),
+                        .map(|((), else_branch): ((), AmlStream<'a>)| Ok(else_branch)),
                     // TODO: can this be `id().map(&[])`?
-                    |input, context| -> ParseResult<'a, 'c, &[u8]> {
+                    |input, context| -> ParseResult<'a, 'c, AmlStream<'a>> {
                         /*
                          * This path parses an DefIfElse that doesn't have an else branch. We simply
                          * return an empty slice, so if the predicate is false, we don't execute
                          * anything.
                          */
-                        Ok((input, context, &[]))
+                        Ok((input, context, AmlStream::empty()))
                     }
                 ))
                 .map_with_context(|((predicate, then_branch), else_branch), context| {

--- a/aml/src/stream.rs
+++ b/aml/src/stream.rs
@@ -225,6 +225,18 @@ mod tests {
         assert_eq!(len_four.take_to_end(3), AmlStream::from_slice(&[3]));
         assert_eq!(len_four.take_to_end(4), AmlStream::empty());
         assert_eq!(len_four.take_to_end(5), AmlStream::empty());
+
+        // Test split_at
+        assert_eq!(len_zero.split_at(0), (AmlStream::empty(), AmlStream::empty()));
+        assert_eq!(len_zero.split_at(1), (AmlStream::empty(), AmlStream::empty()));
+        assert_eq!(len_one.split_at(0), (AmlStream::empty(), AmlStream::from_slice(&[0])));
+        assert_eq!(len_one.split_at(1), (AmlStream::from_slice(&[0]), AmlStream::empty()));
+        assert_eq!(len_four.split_at(0), (AmlStream::empty(), AmlStream::from_slice(&[0, 1, 2, 3])));
+        assert_eq!(len_four.split_at(1), (AmlStream::from_slice(&[0]), AmlStream::from_slice(&[1, 2, 3])));
+        assert_eq!(len_four.split_at(2), (AmlStream::from_slice(&[0, 1]), AmlStream::from_slice(&[2, 3])));
+        assert_eq!(len_four.split_at(3), (AmlStream::from_slice(&[0, 1, 2]), AmlStream::from_slice(&[3])));
+        assert_eq!(len_four.split_at(4), (AmlStream::from_slice(&[0, 1, 2, 3]), AmlStream::empty()));
+        assert_eq!(len_four.split_at(5), (AmlStream::empty(), AmlStream::empty()));
     }
 
     #[test]

--- a/aml/src/stream.rs
+++ b/aml/src/stream.rs
@@ -1,0 +1,190 @@
+use core::{mem, convert::TryInto};
+
+/// A container for the buffer that provides debugging info
+#[derive(Copy, Clone)]
+pub struct AmlStream<'a> {
+    /// The address of the original data, used for debugging only
+    stream_start: usize,
+    /// The slice of data we are currently processing
+    buf: &'a [u8],
+}
+
+/// Slice operations for the stream - if there is an error, the returned stream will be empty
+impl<'a> AmlStream<'a> {
+    pub fn from_slice(slice: &'a [u8]) -> Self {
+        Self {
+            stream_start: slice.as_ptr() as usize,
+            buf: slice,
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self::from_slice(&[])
+    }
+
+    pub fn len(&self) -> usize {
+        self.buf.len()
+    }
+    
+    pub fn slice(&self, start: usize, end: usize) -> Self {
+        if start > self.len() || end > self.len() || start > end {
+            return Self::empty();
+        }
+        Self {
+            stream_start: self.stream_start,
+            buf: &self.buf[start..end]
+        }
+    }
+
+    pub fn content(&self) -> &[u8] {
+        self.buf
+    }
+
+    pub fn slice_from_start(&self, index: usize) -> Self {
+        self.slice(0, index)
+    }
+
+    pub fn slice_to_end(&self, index: usize) -> Self {
+        self.slice(index, self.len())
+    }
+
+    pub fn first(&self) -> Option<&u8> {
+        if self.buf.len() < 1 {
+            return None;
+        }
+        self.buf.first()
+    }
+
+    pub fn get(&self, index: usize) -> Option<&u8> {
+        self.buf.get(index)
+    }
+
+    pub fn get_u16(&self, index: usize) -> Option<u16> {
+        if self.len() - index < mem::size_of::<u16>() {
+            return None;
+        }
+        Some(u16::from_le_bytes(self.buf[index..index + mem::size_of::<u16>()].try_into().ok()?))
+    }
+
+    pub fn get_u32(&self, index: usize) -> Option<u32> {
+        if self.len() - index < mem::size_of::<u32>() {
+            return None;
+        }
+        Some(u32::from_le_bytes(self.buf[index..index + mem::size_of::<u32>()].try_into().ok()?))
+    }
+
+    pub fn get_u64(&self, index: usize) -> Option<u64> {
+        if self.len() - index < mem::size_of::<u64>() {
+            return None;
+        }
+        Some(u64::from_le_bytes(self.buf[index..index + mem::size_of::<u64>()].try_into().ok()?))
+    }
+
+    pub fn split_at(&self, mid: usize) -> (Self, Self) {
+        (self.slice(0, mid), self.slice_to_end(mid))
+    }
+}
+
+impl core::fmt::Debug for AmlStream<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        const PRINT_ALL_LEN: usize = 12;
+        const PRINT_SUMMARY_LEN: usize = 8;
+        let print_all = self.len() <= PRINT_ALL_LEN;
+        let summary = if print_all {
+            self.clone()
+        } else {
+            self.slice_from_start(PRINT_SUMMARY_LEN)
+        };
+        write!(f, "[")?;
+        for b in summary.content() {
+            write!(f, "{:2X},", b)?;
+        }
+        if !print_all {
+            write!(f, "..], len={:#X}, ", self.len())?;
+        } else {
+            write!(f, "], ")?;
+        }
+        const HEADER_LEN: usize = 36;
+        let pos = self.buf.as_ptr() as usize - self.stream_start;
+        write!(f, "pos={:#X}, from header={:#X}, ", pos, pos + HEADER_LEN)?;
+        write!(f, "start={:#X}", self.stream_start)
+    }
+}
+
+impl PartialEq<Self> for AmlStream<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.content() == other.content()
+    }
+}
+
+impl PartialEq<[u8]> for AmlStream<'_> {
+    fn eq(&self, other: &[u8]) -> bool {
+        self.content() == other
+    }
+}
+
+impl PartialEq<&[u8]> for AmlStream<'_> {
+    fn eq(&self, other: &&[u8]) -> bool {
+        self.content() == *other
+    }
+}
+
+impl PartialEq<[u8; 0]> for AmlStream<'_> {
+    fn eq(&self, _other: &[u8; 0]) -> bool {
+        self.len() == 0
+    }
+}
+
+impl PartialEq<&[u8; 0]> for AmlStream<'_> {
+    fn eq(&self, _other: &&[u8; 0]) -> bool {
+        self.len() == 0
+    }
+}
+
+impl PartialEq<[u8; 1]> for AmlStream<'_> {
+    fn eq(&self, other: &[u8; 1]) -> bool {
+        self.content() == other
+    }
+}
+
+impl PartialEq<&[u8; 1]> for AmlStream<'_> {
+    fn eq(&self, other: &&[u8; 1]) -> bool {
+        self.content() == *other
+    }
+}
+
+impl PartialEq<[u8; 2]> for AmlStream<'_> {
+    fn eq(&self, other: &[u8; 2]) -> bool {
+        self.content() == other
+    }
+}
+
+impl PartialEq<&[u8; 2]> for AmlStream<'_> {
+    fn eq(&self, other: &&[u8; 2]) -> bool {
+        self.content() == *other
+    }
+}
+
+impl PartialEq<[u8; 3]> for AmlStream<'_> {
+    fn eq(&self, other: &[u8; 3]) -> bool {
+        self.content() == other
+    }
+}
+
+impl PartialEq<&[u8; 3]> for AmlStream<'_> {
+    fn eq(&self, other: &&[u8; 3]) -> bool {
+        self.content() == *other
+    }
+}
+
+impl PartialEq<[u8; 4]> for AmlStream<'_> {
+    fn eq(&self, other: &[u8; 4]) -> bool {
+        self.content() == other
+    }
+}
+
+impl PartialEq<&[u8; 4]> for AmlStream<'_> {
+    fn eq(&self, other: &&[u8; 4]) -> bool {
+        self.content() == *other
+    }
+}

--- a/aml/src/stream.rs
+++ b/aml/src/stream.rs
@@ -1,4 +1,4 @@
-use core::{mem, convert::TryInto};
+use core::{convert::TryInto, mem};
 
 /// A container for the buffer that provides debugging info
 #[derive(Copy, Clone)]
@@ -12,92 +12,79 @@ pub struct AmlStream<'a> {
 /// Slice operations for the stream - if there is an error, the returned stream will be empty
 impl<'a> AmlStream<'a> {
     pub fn from_slice(slice: &'a [u8]) -> Self {
-        Self {
-            stream_start: slice.as_ptr() as usize,
-            buf: slice,
-        }
+        Self { stream_start: slice.as_ptr() as usize, buf: slice }
     }
 
     pub fn empty() -> Self {
-        Self::from_slice(&[])
+        Self { stream_start: 0, buf: &[] }
     }
 
     pub fn len(&self) -> usize {
         self.buf.len()
     }
-    
-    pub fn slice(&self, start: usize, end: usize) -> Self {
-        if start > self.len() || end > self.len() || start > end {
-            return Self::empty();
-        }
-        Self {
-            stream_start: self.stream_start,
-            buf: &self.buf[start..end]
-        }
-    }
 
-    pub fn content(&self) -> &[u8] {
+    pub fn data(&self) -> &[u8] {
         self.buf
     }
 
-    pub fn slice_from_start(&self, index: usize) -> Self {
-        self.slice(0, index)
-    }
-
-    pub fn slice_to_end(&self, index: usize) -> Self {
-        self.slice(index, self.len())
-    }
-
-    pub fn first(&self) -> Option<&u8> {
-        if self.buf.len() < 1 {
-            return None;
+    pub fn take(&self, start: usize, end: usize) -> Self {
+        if start > self.len() || end > self.len() || start > end {
+            return Self::empty();
         }
-        self.buf.first()
+        Self { stream_start: self.stream_start, buf: &self.buf[start..end] }
     }
 
-    pub fn get(&self, index: usize) -> Option<&u8> {
-        self.buf.get(index)
+    pub fn take_n(&self, index: usize) -> Self {
+        self.take(0, index)
     }
 
-    pub fn get_u16(&self, index: usize) -> Option<u16> {
-        if self.len() - index < mem::size_of::<u16>() {
-            return None;
-        }
-        Some(u16::from_le_bytes(self.buf[index..index + mem::size_of::<u16>()].try_into().ok()?))
-    }
-
-    pub fn get_u32(&self, index: usize) -> Option<u32> {
-        if self.len() - index < mem::size_of::<u32>() {
-            return None;
-        }
-        Some(u32::from_le_bytes(self.buf[index..index + mem::size_of::<u32>()].try_into().ok()?))
-    }
-
-    pub fn get_u64(&self, index: usize) -> Option<u64> {
-        if self.len() - index < mem::size_of::<u64>() {
-            return None;
-        }
-        Some(u64::from_le_bytes(self.buf[index..index + mem::size_of::<u64>()].try_into().ok()?))
+    pub fn take_to_end(&self, index: usize) -> Self {
+        self.take(index, self.len())
     }
 
     pub fn split_at(&self, mid: usize) -> (Self, Self) {
-        (self.slice(0, mid), self.slice_to_end(mid))
+        (self.take(0, mid), self.take_to_end(mid))
+    }
+
+    pub fn first(&self) -> Option<&u8> {
+        self.buf.first()
+    }
+
+    pub fn get_u16(&self) -> Option<u16> {
+        if self.len() < mem::size_of::<u16>() {
+            return None;
+        }
+        Some(u16::from_le_bytes(self.buf[..mem::size_of::<u16>()].try_into().ok()?))
+    }
+
+    pub fn get_u32(&self) -> Option<u32> {
+        if self.len() < mem::size_of::<u32>() {
+            return None;
+        }
+        Some(u32::from_le_bytes(self.buf[..mem::size_of::<u32>()].try_into().ok()?))
+    }
+
+    pub fn get_u64(&self) -> Option<u64> {
+        if self.len() < mem::size_of::<u64>() {
+            return None;
+        }
+        Some(u64::from_le_bytes(self.buf[..mem::size_of::<u64>()].try_into().ok()?))
     }
 }
 
 impl core::fmt::Debug for AmlStream<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if self.stream_start == 0 && self.len() == 0 {
+            return write!(f, "AmlStream::empty()");
+        }
         const PRINT_ALL_LEN: usize = 12;
         const PRINT_SUMMARY_LEN: usize = 8;
         let print_all = self.len() <= PRINT_ALL_LEN;
-        let summary = if print_all {
-            self.clone()
-        } else {
-            self.slice_from_start(PRINT_SUMMARY_LEN)
-        };
+        let summary = self.take_n(PRINT_SUMMARY_LEN);
+        let val = if print_all { self } else { &summary };
         write!(f, "[")?;
-        for b in summary.content() {
-            write!(f, "{:2X},", b)?;
+        for b in val.data() {
+            write!(f, "{:02X},", b)?;
         }
         if !print_all {
             write!(f, "..], len={:#X}, ", self.len())?;
@@ -111,80 +98,230 @@ impl core::fmt::Debug for AmlStream<'_> {
     }
 }
 
+// We ignore the stream_start for comparisons,
+// as this is only used for tests
 impl PartialEq<Self> for AmlStream<'_> {
     fn eq(&self, other: &Self) -> bool {
-        self.content() == other.content()
-    }
-}
-
-impl PartialEq<[u8]> for AmlStream<'_> {
-    fn eq(&self, other: &[u8]) -> bool {
-        self.content() == other
+        self.data() == other.data()
     }
 }
 
 impl PartialEq<&[u8]> for AmlStream<'_> {
     fn eq(&self, other: &&[u8]) -> bool {
-        self.content() == *other
+        self.data() == *other
     }
 }
 
-impl PartialEq<[u8; 0]> for AmlStream<'_> {
-    fn eq(&self, _other: &[u8; 0]) -> bool {
-        self.len() == 0
+impl<const N: usize> PartialEq<&[u8; N]> for AmlStream<'_> {
+    fn eq(&self, other: &&[u8; N]) -> bool {
+        self.data() == *other
     }
 }
 
-impl PartialEq<&[u8; 0]> for AmlStream<'_> {
-    fn eq(&self, _other: &&[u8; 0]) -> bool {
-        self.len() == 0
-    }
-}
+#[cfg(test)]
+mod tests {
+    use num::Integer;
 
-impl PartialEq<[u8; 1]> for AmlStream<'_> {
-    fn eq(&self, other: &[u8; 1]) -> bool {
-        self.content() == other
-    }
-}
+    use super::*;
 
-impl PartialEq<&[u8; 1]> for AmlStream<'_> {
-    fn eq(&self, other: &&[u8; 1]) -> bool {
-        self.content() == *other
-    }
-}
+    #[test]
+    fn test_stream_cmp() {
+        let v: alloc::vec::Vec<u8> = alloc::vec![0, 1, 2, 3, 4];
 
-impl PartialEq<[u8; 2]> for AmlStream<'_> {
-    fn eq(&self, other: &[u8; 2]) -> bool {
-        self.content() == other
-    }
-}
+        // test non-const buf compare
+        assert_eq!(AmlStream::from_slice(&[]), &v[..0]);
+        assert_ne!(AmlStream::from_slice(&[]), &v[..1]);
+        assert_ne!(AmlStream::from_slice(&[0]), &v[..0]);
+        assert_eq!(AmlStream::from_slice(&[0]), &v[..1]);
+        assert_eq!(AmlStream::from_slice(&[0, 1]), &v[..2]);
+        // ensure compare is still non-const even if the compiler gets smarter
+        assert_eq!(
+            AmlStream::from_slice(&[0, 2, 4]),
+            &v.iter().filter_map(|i| if i.is_even() { Some(*i) } else { None }).collect::<alloc::vec::Vec<u8>>()[..]
+        );
+        assert_eq!(AmlStream::from_slice(&[0, 1, 2, 3, 4]), &v[..]);
+        assert_ne!(AmlStream::from_slice(&[0, 0, 0, 0, 0]), &v[..]);
+        assert_ne!(AmlStream::from_slice(&[0, 1, 2, 3, 4, 5]), &v[..]);
 
-impl PartialEq<&[u8; 2]> for AmlStream<'_> {
-    fn eq(&self, other: &&[u8; 2]) -> bool {
-        self.content() == *other
-    }
-}
+        // check various sizes of const buf compare
+        assert_eq!(AmlStream::from_slice(&[]), &[]);
+        assert_ne!(AmlStream::from_slice(&[]), &[0]);
 
-impl PartialEq<[u8; 3]> for AmlStream<'_> {
-    fn eq(&self, other: &[u8; 3]) -> bool {
-        self.content() == other
-    }
-}
+        assert_ne!(AmlStream::from_slice(&[0]), &[]);
+        assert_eq!(AmlStream::from_slice(&[0]), &[0]);
 
-impl PartialEq<&[u8; 3]> for AmlStream<'_> {
-    fn eq(&self, other: &&[u8; 3]) -> bool {
-        self.content() == *other
-    }
-}
+        assert_eq!(AmlStream::from_slice(&[0, 1]), &[0, 1]);
+        assert_ne!(AmlStream::from_slice(&[0, 1]), &[0, 2]);
 
-impl PartialEq<[u8; 4]> for AmlStream<'_> {
-    fn eq(&self, other: &[u8; 4]) -> bool {
-        self.content() == other
-    }
-}
+        assert_ne!(AmlStream::from_slice(&[0, 1]), &[0, 1, 2]);
+        assert_eq!(AmlStream::from_slice(&[0, 1, 2]), &[0, 1, 2]);
+        assert_ne!(AmlStream::from_slice(&[0, 1, 2]), &[0, 2, 1]);
 
-impl PartialEq<&[u8; 4]> for AmlStream<'_> {
-    fn eq(&self, other: &&[u8; 4]) -> bool {
-        self.content() == *other
+        assert_ne!(AmlStream::from_slice(&[0, 1, 2]), &[0, 1, 2, 3]);
+        assert_eq!(AmlStream::from_slice(&[0, 1, 2, 3]), &[0, 1, 2, 3]);
+        assert_ne!(AmlStream::from_slice(&[0, 1, 2, 3]), &[3, 2, 1, 0]);
+
+        // Check comparison of streams
+        assert_eq!(AmlStream::from_slice(&[]), AmlStream::empty());
+        assert_ne!(AmlStream::from_slice(&[0]), AmlStream::empty());
+        assert_eq!(AmlStream::from_slice(&[0, 1, 2]), AmlStream::from_slice(&[0, 1, 2]));
+        assert_ne!(AmlStream::from_slice(&[0, 1, 2]), AmlStream::from_slice(&[1, 2, 3]));
+    }
+
+    #[test]
+    fn test_take() {
+        let empty = AmlStream::empty();
+        let len_zero = AmlStream::from_slice(&[]);
+        let len_one = AmlStream::from_slice(&[0]);
+        let len_four = AmlStream::from_slice(&[0, 1, 2, 3]);
+
+        // Test first
+        assert_eq!(empty.first(), None);
+        assert_eq!(len_zero.first(), None);
+        assert_eq!(len_one.first(), Some(&0));
+        assert_eq!(len_four.first(), Some(&0));
+
+        // Test take
+        assert_eq!(len_zero.take(0, 0), AmlStream::empty());
+        assert_eq!(len_one.take(0, 0), AmlStream::empty());
+        assert_eq!(len_four.take(0, 0), AmlStream::empty());
+        assert_eq!(len_zero.take(0, 0), AmlStream::empty());
+        assert_eq!(len_one.take(0, 1), AmlStream::from_slice(&[0]));
+        assert_eq!(len_four.take(0, 1), AmlStream::from_slice(&[0]));
+        assert_eq!(len_four.take(1, 1), AmlStream::empty());
+        assert_eq!(len_one.take(1, 2), AmlStream::empty());
+        assert_eq!(len_four.take(1, 2), AmlStream::from_slice(&[1]));
+        assert_eq!(len_four.take(2, 3), AmlStream::from_slice(&[2]));
+        assert_eq!(len_four.take(3, 4), AmlStream::from_slice(&[3]));
+        assert_eq!(len_four.take(3, 5), AmlStream::empty());
+        assert_eq!(len_four.take(0, 2), AmlStream::from_slice(&[0, 1]));
+        assert_eq!(len_four.take(1, 3), AmlStream::from_slice(&[1, 2]));
+        assert_eq!(len_four.take(2, 4), AmlStream::from_slice(&[2, 3]));
+        assert_eq!(len_four.take(1, 4), AmlStream::from_slice(&[1, 2, 3]));
+        assert_eq!(len_four.take(0, 4), AmlStream::from_slice(&[0, 1, 2, 3]));
+        assert_eq!(len_four.take(0, 5), AmlStream::empty());
+
+        // Test take_n
+        assert_eq!(len_zero.take_n(0), AmlStream::empty());
+        assert_eq!(len_one.take_n(0), AmlStream::empty());
+        assert_eq!(len_four.take_n(0), AmlStream::empty());
+        assert_eq!(len_zero.take_n(1), AmlStream::empty());
+        assert_eq!(len_four.take_n(5), AmlStream::empty());
+        assert_eq!(len_one.take_n(1), AmlStream::from_slice(&[0]));
+        assert_eq!(len_four.take_n(1), AmlStream::from_slice(&[0]));
+        assert_eq!(len_one.take_n(2), AmlStream::empty());
+        assert_eq!(len_four.take_n(2), AmlStream::from_slice(&[0, 1]));
+        assert_eq!(len_four.take_n(3), AmlStream::from_slice(&[0, 1, 2]));
+        assert_eq!(len_four.take_n(4), AmlStream::from_slice(&[0, 1, 2, 3]));
+        assert_eq!(len_four.take_n(5), AmlStream::empty());
+
+        // Test take_to_end
+        assert_eq!(len_zero.take_to_end(0), AmlStream::empty());
+        assert_eq!(len_one.take_to_end(0), AmlStream::from_slice(&[0]));
+        assert_eq!(len_one.take_to_end(1), AmlStream::empty());
+        assert_eq!(len_four.take_to_end(0), AmlStream::from_slice(&[0, 1, 2, 3]));
+        assert_eq!(len_four.take_to_end(1), AmlStream::from_slice(&[1, 2, 3]));
+        assert_eq!(len_four.take_to_end(2), AmlStream::from_slice(&[2, 3]));
+        assert_eq!(len_four.take_to_end(3), AmlStream::from_slice(&[3]));
+        assert_eq!(len_four.take_to_end(4), AmlStream::empty());
+        assert_eq!(len_four.take_to_end(5), AmlStream::empty());
+    }
+
+    #[test]
+    fn test_get_as() {
+        let empty = AmlStream::empty();
+        let n_8 = AmlStream::from_slice(&[4]);
+        let n_16 = AmlStream::from_slice(&[3, 4]);
+        let n_32 = AmlStream::from_slice(&[0xa, 0xb, 0xc, 0xd]);
+        let n_64 = AmlStream::from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
+
+        // test get_u16
+        assert_eq!(empty.get_u16(), None);
+        assert_eq!(n_8.get_u16(), None);
+        assert_eq!(n_16.get_u16(), Some(0x0403));
+        assert_eq!(n_32.get_u16(), Some(0x0b0a));
+        assert_eq!(n_64.get_u16(), Some(0x0201));
+
+        // test get_u32
+        assert_eq!(empty.get_u32(), None);
+        assert_eq!(n_8.get_u32(), None);
+        assert_eq!(n_16.get_u32(), None);
+        assert_eq!(n_32.get_u32(), Some(0x0d0c0b0a));
+        assert_eq!(n_64.get_u32(), Some(0x04030201));
+
+        // test get_u64
+        assert_eq!(empty.get_u64(), None);
+        assert_eq!(n_8.get_u64(), None);
+        assert_eq!(n_16.get_u64(), None);
+        assert_eq!(n_32.get_u64(), None);
+        assert_eq!(n_64.get_u64(), Some(0x0807060504030201));
+    }
+
+    #[test]
+    fn test_debug() {
+        let empty = AmlStream::empty();
+        let len_zero = AmlStream::from_slice(&[]);
+        let len_one = AmlStream::from_slice(&[0xa]);
+        let len_eight = AmlStream::from_slice(&[0xa, 0xb, 0xa, 0xc, 0xd, 0xb, 0xa, 0xc]);
+        let len_twelve = AmlStream::from_slice(&[0xa, 0xb, 0xa, 0xc, 0xd, 0xb, 0xa, 0xc, 0xf, 0xe, 0xd, 0xc]);
+        let len_thirteen = AmlStream::from_slice(&[0xf, 0xa, 0xb, 0xa, 0xc, 0xd, 0xb, 0xa, 0xc, 0xf, 0xe, 0xd, 0xc]);
+
+        // test Debug formatting
+        assert_eq!(alloc::format!("{:?}", empty), "AmlStream::empty()");
+        assert_eq!(alloc::format!("{empty:?}"), "AmlStream::empty()");
+        assert_eq!(
+            alloc::format!("{:?}", len_zero),
+            alloc::format!("[], pos={:#X}, from header={:#X}, start={:#X}", 0, 36, len_zero.stream_start)
+        );
+        assert_eq!(
+            alloc::format!("{:?}", len_one),
+            alloc::format!("[0A,], pos={:#X}, from header={:#X}, start={:#X}", 0, 36, len_one.stream_start)
+        );
+        assert_eq!(
+            alloc::format!("{:?}", len_eight),
+            alloc::format!(
+                "[0A,0B,0A,0C,0D,0B,0A,0C,], pos={:#X}, from header={:#X}, start={:#X}",
+                0,
+                36,
+                len_eight.stream_start
+            )
+        );
+        assert_eq!(
+            alloc::format!("{:?}", len_twelve),
+            alloc::format!(
+                "[0A,0B,0A,0C,0D,0B,0A,0C,0F,0E,0D,0C,], pos={:#X}, from header={:#X}, start={:#X}",
+                0,
+                36,
+                len_twelve.stream_start
+            )
+        );
+        assert_eq!(
+            alloc::format!("{:?}", len_thirteen),
+            alloc::format!(
+                "[0F,0A,0B,0A,0C,0D,0B,0A,..], len={:#X}, pos={:#X}, from header={:#X}, start={:#X}",
+                13,
+                0,
+                36,
+                len_thirteen.stream_start
+            )
+        );
+        assert_eq!(
+            alloc::format!("{:?}", len_thirteen.take_n(12)),
+            alloc::format!(
+                "[0F,0A,0B,0A,0C,0D,0B,0A,0C,0F,0E,0D,], pos={:#X}, from header={:#X}, start={:#X}",
+                0,
+                36,
+                len_thirteen.stream_start
+            )
+        );
+        assert_eq!(
+            alloc::format!("{:?}", len_thirteen.take_to_end(1)),
+            alloc::format!(
+                "[0A,0B,0A,0C,0D,0B,0A,0C,0F,0E,0D,0C,], pos={:#X}, from header={:#X}, start={:#X}",
+                1,
+                37,
+                len_thirteen.stream_start
+            )
+        );
     }
 }

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -619,7 +619,7 @@ where
                             &context.current_scope,
                             AmlValue::Method {
                                 flags: MethodFlags::from(flags),
-                                code: MethodCode::Aml(code.content().to_vec())
+                                code: MethodCode::Aml(code.data().to_vec())
                             },
                         )
                     );
@@ -945,18 +945,18 @@ where
              * Using `position` isn't very efficient here, but is probably fine because the
              * strings are usually quite short.
              */
-            let nul_position = match input.content().iter().position(|&c| c == b'\0') {
+            let nul_position = match input.data().iter().position(|&c| c == b'\0') {
                 Some(position) => position,
                 None => return Err((input, context, Propagate::Err(AmlError::UnterminatedStringConstant))),
             };
 
             let (s, remaining) = input.split_at(nul_position);
-            let string = String::from(match str::from_utf8(s.content()) {
+            let string = String::from(match str::from_utf8(s.data()) {
                 Ok(string) => string,
                 Err(_) => return Err((input, context, Propagate::Err(AmlError::InvalidStringConstant))),
             });
 
-            Ok((remaining.slice_to_end(1), context, AmlValue::String(string)))
+            Ok((remaining.take_to_end(1), context, AmlValue::String(string)))
         };
 
         let (new_input, context, op) = take().parse(input, context)?;

--- a/aml/src/test_utils.rs
+++ b/aml/src/test_utils.rs
@@ -77,7 +77,7 @@ pub(crate) fn make_test_context() -> AmlContext {
 pub(crate) macro check_err($parse: expr, $error: pat, $remains: expr) {
     match $parse {
         Ok((remains, _, result)) => panic!("Expected Err, got {:#?}. Remaining = {:#x?}", result, remains),
-        Err((remains, _, Propagate::Err($error))) if *remains == *$remains => (),
+        Err((remains, _, Propagate::Err($error))) if remains == $remains => (),
         Err((remains, _, Propagate::Err($error))) => {
             panic!("Correct error, incorrect stream returned: {:#x?}", remains)
         }
@@ -87,7 +87,7 @@ pub(crate) macro check_err($parse: expr, $error: pat, $remains: expr) {
 
 pub(crate) macro check_ok($parse: expr, $expected: expr, $remains: expr) {
     match $parse {
-        Ok((remains, _, ref result)) if remains == *$remains && result == &$expected => (),
+        Ok((remains, _, ref result)) if remains == $remains && result == &$expected => (),
         Ok((remains, _, ref result)) if result == &$expected => {
             panic!("Correct result, incorrect slice returned: {:x?}", remains)
         }
@@ -98,7 +98,7 @@ pub(crate) macro check_ok($parse: expr, $expected: expr, $remains: expr) {
 
 pub(crate) macro check_ok_value($parse: expr, $expected: expr, $remains: expr) {
     match $parse {
-        Ok((remains, _, ref result)) if remains == *$remains && crudely_cmp_values(result, &$expected) => (),
+        Ok((remains, _, ref result)) if remains == $remains && crudely_cmp_values(result, &$expected) => (),
         Ok((remains, _, ref result)) if crudely_cmp_values(result, &$expected) => {
             panic!("Correct result, incorrect slice returned: {:x?}", remains)
         }


### PR DESCRIPTION
New input buffer is AmlStream. Original buffer address is kept with the buffer, providing additional debug info.
- Input type of each Parser closure is now AmlStream
- Aml Functions store their data as vec!(&[u8]), but a new AmlStream is created when the function is executed
- Debug trait provides hex output that can be matched with the output of the `acpidump` relatively easily, including offset from the start of the header.
  `buf = [10,4E,B8,2E,5F,53,42,5F,..], len=0x4B559, pos=0x4726, from header=0x474A, start=0x7FB8A4D73034` vs.
  `    4740: 57 41 4B 5F 68 A4 41 4D 30 30 10 4E B8 2E 5F 53  WAK_h.AM00.N.._S`