### PR TITLE
Aml: Add fold/level_fold/find_map iterators and lookup handle->name

### DIFF
--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -738,6 +738,7 @@ pub enum AmlError {
     /// `AmlName` is the name of the entire sub-level/value.
     LevelDoesNotExist(AmlName),
     ValueDoesNotExist(AmlName),
+    HandleDoesNotExist(AmlHandle),
     /// Produced when two values with the same name are added to the namespace.
     NameCollision(AmlName),
     TriedToRemoveRootNamespace,

--- a/aml_tester/src/main.rs
+++ b/aml_tester/src/main.rs
@@ -9,7 +9,7 @@
  *      - For failing tests, print out a nice summary of the errors for each file
  */
 
-use aml::{AmlContext, DebugVerbosity};
+use aml::{AmlContext, DebugVerbosity, AmlName};
 use clap::{Arg, ArgAction, ArgGroup};
 use std::{
     collections::HashSet,


### PR DESCRIPTION
I only really needed reverse name lookup, but I implemented some iterators along the way. `fold` and `find_map` iterate over all values. `find_map` does a sort of short circuit to reduce the number of visits, but does not necessarily stop on the first correct result. `level_fold` is similar to traverse but returns a value.