### PR TITLE
AML: `DefSizeOf` implementation

### DIFF
--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -796,6 +796,7 @@ pub enum AmlError {
     TypeCannotBeSliced(AmlType),
     TypeCannotBeWrittenToBufferField(AmlType),
     BufferFieldIndexesOutOfBounds,
+    InvalidSizeOfApplication(AmlType),
 
     /// Unimplemented functionality - return error rather than abort
     Unimplemented,

--- a/aml/src/opcode.rs
+++ b/aml/src/opcode.rs
@@ -68,6 +68,7 @@ pub const DEF_SHIFT_LEFT: u8 = 0x79;
 pub const DEF_SHIFT_RIGHT: u8 = 0x7a;
 pub const DEF_AND_OP: u8 = 0x7b;
 pub const DEF_CONCAT_RES_OP: u8 = 0x84;
+pub const DEF_SIZE_OF_OP: u8 = 0x87;
 pub const DEF_OBJECT_TYPE_OP: u8 = 0x8e;
 pub const DEF_L_AND_OP: u8 = 0x90;
 pub const DEF_L_OR_OP: u8 = 0x91;

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -263,6 +263,21 @@ impl AmlValue {
         }
     }
 
+    /// Returns the `SizeOf (x)` application result as specified in ACPI 6.2 §19.6.125
+    pub fn size_of(&self) -> Result<u64, AmlError> {
+        match self {
+            // For a buffer, returns the size in bytes of the data
+            AmlValue::Buffer(value) => Ok(value.lock().len() as u64),
+            // For a string, returns the size in bytes (without NULL)
+            AmlValue::String(value) => Ok(value.len() as u64),
+            // For a package, returns the number of elements
+            AmlValue::Package(value) => Ok(value.len() as u64),
+            // TODO: For an Object Reference, the size of the object is returned
+            // Other data types cause a fatal run-time error
+            _ => Err(AmlError::InvalidSizeOfApplication(self.type_of())),
+        }
+    }
+
     pub fn as_bool(&self) -> Result<bool, AmlError> {
         match self {
             AmlValue::Boolean(value) => Ok(*value),


### PR DESCRIPTION
The PR implements `SizeOf (x)` operation for String, Buffer and Package types (the functionality for Object References isn't in place at the moment, so I marked it as `TODO`)