### PR TITLE
AML: Implement OpReg-relative PkgLength parser

### DIFF
--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -706,6 +706,11 @@ pub enum AmlError {
     MalformedStream,
     InvalidNameSeg,
     InvalidPkgLength,
+    /// Invalid PkgLength relative to an OperationRegion
+    InvalidRegionPkgLength {
+        region_bit_length: u64,
+        raw_length: u32,
+    },
     InvalidFieldFlags,
     UnterminatedStringConstant,
     InvalidStringConstant,


### PR DESCRIPTION
This PR fixes the issue #187 by implementing an additional kind of `PkgLength`, which is checked against its OperationRegion instead of the AML input slice.