### PR TITLE
AML: Fix DefPackage len < NumElements failing

### DIFF
--- a/aml/src/expression.rs
+++ b/aml/src/expression.rs
@@ -624,9 +624,14 @@ where
                         package_contents.push(value);
                     }
 
-                    if package_contents.len() != num_elements as usize {
+                    // ACPI6.2, §19.6.101 specifies that if NumElements is present and is greater
+                    // than the number of entries in the PackageList, the default entry of type
+                    // Uninitialized is used
+                    if package_contents.len() > num_elements as usize {
                         return Err((input, context, Propagate::Err(AmlError::MalformedPackage)));
                     }
+
+                    package_contents.resize(num_elements as usize, AmlValue::Uninitialized);
 
                     Ok((input, context, AmlValue::Package(package_contents)))
                 }

--- a/aml/src/test_utils.rs
+++ b/aml/src/test_utils.rs
@@ -119,6 +119,10 @@ pub(crate) fn crudely_cmp_values(a: &AmlValue, b: &AmlValue) -> bool {
     use crate::value::MethodCode;
 
     match a {
+        AmlValue::Uninitialized => match b {
+            AmlValue::Uninitialized => true,
+            _ => false,
+        },
         AmlValue::Boolean(a) => match b {
             AmlValue::Boolean(b) => a == b,
             _ => false,

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -174,6 +174,7 @@ impl fmt::Debug for MethodCode {
 
 #[derive(Clone, Debug)]
 pub enum AmlValue {
+    Uninitialized,
     Boolean(bool),
     Integer(u64),
     String(String),
@@ -246,6 +247,7 @@ impl AmlValue {
 
     pub fn type_of(&self) -> AmlType {
         match self {
+            AmlValue::Uninitialized => AmlType::Uninitialized,
             AmlValue::Boolean(_) => AmlType::Integer,
             AmlValue::Integer(_) => AmlType::Integer,
             AmlValue::String(_) => AmlType::String,


### PR DESCRIPTION
This PR fixes the issue when entry count in DefPackage is less than NumElements specified by it:

```
// As found in the DSDT of Lenovo ThinkPad T430
...
Name (BT0P, Package (0x04){})
...
```

The spec says if NumElements is greater than the number of values provided, the rest should just be filled with an Uninitialized type value.