### PR TITLE
aml: Implement DefOr, DefSubtract and DefLNot opcodes

### DIFF
--- a/aml/src/expression.rs
+++ b/aml/src/expression.rs
@@ -105,7 +105,7 @@ where
     opcode(opcode::DEF_SUBTRACT_OP)
         .then(comment_scope(
             DebugVerbosity::AllScopes,
-            "DefAdd",
+            "DefSubtract",
             term_arg().then(term_arg()).then(target()).map_with_context(
                 |((left_arg, right_arg), target), context| {
                     let left = try_with_context!(context, left_arg.as_integer(context));
@@ -419,7 +419,7 @@ where
             "DefLNot",
             term_arg().map_with_context(|arg, context| {
                 let operand = try_with_context!(context, arg.as_bool());
-                (Ok(AmlValue::Boolean(operand)), context)
+                (Ok(AmlValue::Boolean(!operand)), context)
             }),
         ))
         .map(|((), result)| Ok(result))

--- a/aml/src/expression.rs
+++ b/aml/src/expression.rs
@@ -37,6 +37,7 @@ where
         "ExpressionOpcode",
         choice!(
             def_add(),
+            def_subtract(),
             def_and(),
             def_or(),
             def_buffer(),
@@ -83,6 +84,32 @@ where
                     let left = try_with_context!(context, left_arg.as_integer(context));
                     let right = try_with_context!(context, right_arg.as_integer(context));
                     let result = AmlValue::Integer(left.wrapping_add(right));
+
+                    try_with_context!(context, context.store(target, result.clone()));
+                    (Ok(result), context)
+                },
+            ),
+        ))
+        .map(|((), result)| Ok(result))
+}
+
+pub fn def_subtract<'a, 'c>() -> impl Parser<'a, 'c, AmlValue>
+where
+    'c: 'a,
+{
+    /*
+     * DefSubtract := 0x74 Operand Operand Target
+     * Operand := TermArg => Integer
+     */
+    opcode(opcode::DEF_SUBTRACT_OP)
+        .then(comment_scope(
+            DebugVerbosity::AllScopes,
+            "DefAdd",
+            term_arg().then(term_arg()).then(target()).map_with_context(
+                |((left_arg, right_arg), target), context| {
+                    let left = try_with_context!(context, left_arg.as_integer(context));
+                    let right = try_with_context!(context, right_arg.as_integer(context));
+                    let result = AmlValue::Integer(left.wrapping_sub(right));
 
                     try_with_context!(context, context.store(target, result.clone()));
                     (Ok(result), context)

--- a/aml/src/expression.rs
+++ b/aml/src/expression.rs
@@ -53,6 +53,7 @@ where
             def_l_not_equal(),
             def_l_and(),
             def_l_or(),
+            def_l_not(),
             def_mid(),
             def_object_type(),
             def_package(),
@@ -399,6 +400,26 @@ where
                 let left = try_with_context!(context, left_arg.as_bool());
                 let right = try_with_context!(context, right_arg.as_bool());
                 (Ok(AmlValue::Boolean(left || right)), context)
+            }),
+        ))
+        .map(|((), result)| Ok(result))
+}
+
+fn def_l_not<'a, 'c>() -> impl Parser<'a, 'c, AmlValue>
+where
+    'c: 'a,
+{
+    /*
+     * DefLNot := 0x92 Operand
+     * Operand := TermArg => Integer
+     */
+    opcode(opcode::DEF_L_NOT_OP)
+        .then(comment_scope(
+            DebugVerbosity::AllScopes,
+            "DefLNot",
+            term_arg().map_with_context(|arg, context| {
+                let operand = try_with_context!(context, arg.as_bool());
+                (Ok(AmlValue::Boolean(operand)), context)
             }),
         ))
         .map(|((), result)| Ok(result))

--- a/aml/src/expression.rs
+++ b/aml/src/expression.rs
@@ -38,6 +38,7 @@ where
         choice!(
             def_add(),
             def_and(),
+            def_or(),
             def_buffer(),
             def_concat(),
             def_concat_res(),
@@ -108,6 +109,32 @@ where
                     let left = try_with_context!(context, left_arg.as_integer(context));
                     let right = try_with_context!(context, right_arg.as_integer(context));
                     let result = AmlValue::Integer(left & right);
+
+                    try_with_context!(context, context.store(target, result.clone()));
+                    (Ok(result), context)
+                },
+            ),
+        ))
+        .map(|((), result)| Ok(result))
+}
+
+pub fn def_or<'a, 'c>() -> impl Parser<'a, 'c, AmlValue>
+where
+    'c: 'a,
+{
+    /*
+     * DefOr := 0x7d Operand Operand Target
+     * Operand := TermArg => Integer
+     */
+    opcode(opcode::DEF_OR_OP)
+        .then(comment_scope(
+            DebugVerbosity::AllScopes,
+            "DefOr",
+            term_arg().then(term_arg()).then(target()).map_with_context(
+                |((left_arg, right_arg), target), context| {
+                    let left = try_with_context!(context, left_arg.as_integer(context));
+                    let right = try_with_context!(context, right_arg.as_integer(context));
+                    let result = AmlValue::Integer(left | right);
 
                     try_with_context!(context, context.store(target, result.clone()));
                     (Ok(result), context)

--- a/aml/src/opcode.rs
+++ b/aml/src/opcode.rs
@@ -64,6 +64,7 @@ pub const EXT_DEF_SLEEP_OP: u8 = 0x22;
 pub const DEF_STORE_OP: u8 = 0x70;
 pub const DEF_ADD_OP: u8 = 0x72;
 pub const DEF_CONCAT_OP: u8 = 0x73;
+pub const DEF_SUBTRACT_OP: u8 = 0x74;
 pub const DEF_INCREMENT_OP: u8 = 0x75;
 pub const DEF_DECREMENT_OP: u8 = 0x76;
 pub const DEF_SHIFT_LEFT: u8 = 0x79;

--- a/aml/src/opcode.rs
+++ b/aml/src/opcode.rs
@@ -69,6 +69,7 @@ pub const DEF_DECREMENT_OP: u8 = 0x76;
 pub const DEF_SHIFT_LEFT: u8 = 0x79;
 pub const DEF_SHIFT_RIGHT: u8 = 0x7a;
 pub const DEF_AND_OP: u8 = 0x7b;
+pub const DEF_OR_OP: u8 = 0x7d;
 pub const DEF_CONCAT_RES_OP: u8 = 0x84;
 pub const DEF_SIZE_OF_OP: u8 = 0x87;
 pub const DEF_OBJECT_TYPE_OP: u8 = 0x8e;


### PR DESCRIPTION
This PR implements some simple opcodes currently missing, but required for real-hardware function.