### PR TITLE
fix: issue #200 increment `local_nmi_line_count` and `processor_count` on X2APIC

### DIFF
--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -133,6 +133,7 @@ impl Madt {
                 MadtEntry::InterruptSourceOverride(_) => iso_count += 1,
                 MadtEntry::NmiSource(_) => nmi_source_count += 1,
                 MadtEntry::LocalApicNmi(_) => local_nmi_line_count += 1,
+                MadtEntry::X2ApicNmi(_) => local_nmi_line_count += 1,
                 MadtEntry::LocalApic(_) => processor_count += 1,
                 MadtEntry::LocalX2Apic(_) => processor_count += 1,
                 _ => (),

--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -134,6 +134,7 @@ impl Madt {
                 MadtEntry::NmiSource(_) => nmi_source_count += 1,
                 MadtEntry::LocalApicNmi(_) => local_nmi_line_count += 1,
                 MadtEntry::LocalApic(_) => processor_count += 1,
+                MadtEntry::LocalX2Apic(_) => processor_count += 1,
                 _ => (),
             }
         }


### PR DESCRIPTION
`local_nmi_line_count` and `processor_count` must be increment if `MadtEntry::X2ApicNmi` and `MadtEntry::LocalX2Apic` are found. Otherwise, the index out of bounds panics will be invoked when accessing `local_apic_nmi_lines` and `application_processors`.

- https://github.com/rust-osdev/acpi/blob/baf55fe8a0530f8c84f9040d1f940ae3a0a7d993/acpi/src/madt.rs#L264
- https://github.com/rust-osdev/acpi/blob/baf55fe8a0530f8c84f9040d1f940ae3a0a7d993/acpi/src/madt.rs#L204