### PR TITLE
aml: add extra debug info on parsing error

### DIFF
--- a/aml/src/lib.rs
+++ b/aml/src/lib.rs
@@ -60,7 +60,11 @@ pub mod value;
 
 pub use crate::{namespace::*, value::AmlValue};
 
-use alloc::{boxed::Box, string::ToString};
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+};
 use core::mem;
 use log::{error, warn};
 use misc::{ArgNum, LocalNum};
@@ -143,6 +147,29 @@ impl AmlContext {
     }
 
     pub fn parse_table(&mut self, stream: &[u8]) -> Result<(), AmlError> {
+        fn stream_context(stream: &[u8], err_buf: &[u8]) -> String {
+            const BEFORE_LEN: usize = 4;
+            const ABBREV_LEN: usize = 4;
+            let abbreviated = if err_buf.len() >= ABBREV_LEN { &err_buf[..ABBREV_LEN] } else { err_buf };
+
+            if let Some(position) = (err_buf.as_ptr() as usize).checked_sub(stream.as_ptr() as usize) {
+                if position <= stream.len() {
+                    let before = if position > BEFORE_LEN {
+                        &stream[position - BEFORE_LEN..position]
+                    } else {
+                        &stream[..position]
+                    };
+                    return format!(
+                        "position {:#X}: preceding {:X?}, buf {:X?}",
+                        position + 36,
+                        before,
+                        abbreviated
+                    );
+                }
+            }
+            format!("buf {:X?}", abbreviated)
+        }
+
         if stream.len() == 0 {
             return Err(AmlError::UnexpectedEndOfStream);
         }
@@ -150,8 +177,8 @@ impl AmlContext {
         let table_length = PkgLength::from_raw_length(stream, stream.len() as u32).unwrap();
         match term_object::term_list(table_length).parse(stream, self) {
             Ok(_) => Ok(()),
-            Err((_, _, Propagate::Err(err))) => {
-                error!("Failed to parse AML stream. Err = {:?}", err);
+            Err((err_buf, _, Propagate::Err(err))) => {
+                error!("Failed to parse AML stream. Err = {:?}, {}", err, stream_context(stream, err_buf));
                 Err(err)
             }
             Err((_, _, other)) => {

--- a/aml/src/test_utils.rs
+++ b/aml/src/test_utils.rs
@@ -50,22 +50,22 @@ impl Handler for TestHandler {
         unimplemented!()
     }
 
-    fn read_pci_u8(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16) -> u8 {
+    fn read_pci_u8(&self, _segment: u16, _bus: u8, _device: u8, _function: u8, _offset: u16) -> u8 {
         unimplemented!()
     }
-    fn read_pci_u16(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16) -> u16 {
+    fn read_pci_u16(&self, _segment: u16, _bus: u8, _device: u8, _function: u8, _offset: u16) -> u16 {
         unimplemented!()
     }
-    fn read_pci_u32(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16) -> u32 {
+    fn read_pci_u32(&self, _segment: u16, _bus: u8, _device: u8, _function: u8, _offset: u16) -> u32 {
         unimplemented!()
     }
-    fn write_pci_u8(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16, _value: u8) {
+    fn write_pci_u8(&self, _segment: u16, _bus: u8, _device: u8, _function: u8, _offset: u16, _value: u8) {
         unimplemented!()
     }
-    fn write_pci_u16(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16, _value: u16) {
+    fn write_pci_u16(&self, _segment: u16, _bus: u8, _device: u8, _function: u8, _offset: u16, _value: u16) {
         unimplemented!()
     }
-    fn write_pci_u32(&self, _segment: u16, _bus: u8, device: u8, _function: u8, _offset: u16, _value: u32) {
+    fn write_pci_u32(&self, _segment: u16, _bus: u8, _device: u8, _function: u8, _offset: u16, _value: u32) {
         unimplemented!()
     }
     fn stall(&self, _microseconds: u64) {


### PR DESCRIPTION
Adds a more detailed error message that will print out the position in the buffer and a few bytes before and after the error.

Also fixes an unused argument warning in the test code.