### PR TITLE
Draft: AML: allow field in ToInteger

### DIFF
--- a/aml/src/expression.rs
+++ b/aml/src/expression.rs
@@ -812,6 +812,9 @@ where
                 AmlValue::Buffer(data) => {
                     AmlValue::Integer(try_with_context!(context, AmlValue::Buffer(data).as_integer(context)))
                 }
+                AmlValue::Field { .. } => {
+                    AmlValue::Integer(try_with_context!(context, operand.as_integer(context)))
+                }
                 AmlValue::String(string) => AmlValue::Integer(try_with_context!(
                     context,
                     if string.starts_with("0x") {


### PR DESCRIPTION
Seen in the wild, Field is used as argument to ToInteger, even though the spec says it is not an option.