### PR TITLE
AML: Allow Field in ToInteger (rebased)

### DIFF
--- a/aml/src/expression.rs
+++ b/aml/src/expression.rs
@@ -812,6 +812,9 @@ where
                 AmlValue::Buffer(data) => {
                     AmlValue::Integer(try_with_context!(context, AmlValue::Buffer(data).as_integer(context)))
                 }
+                AmlValue::Field { .. } => {
+                    AmlValue::Integer(try_with_context!(context, operand.as_integer(context)))
+                }
                 AmlValue::String(string) => AmlValue::Integer(try_with_context!(
                     context,
                     if string.starts_with("0x") {


### PR DESCRIPTION
This PR replaces #209 - it is just a rebase, but I wanted to do it cleanly.

On my HP Laptop, Field is used as argument to ToInteger, even though the spec says it is not an option.

This is the declaration of VDID.
```
            OperationRegion (RPXX, SystemMemory, GMIO (^_ADR, _ADR), 0x10)

   1737E: 5B 80 52 50 58 58 00 47 4D 49 4F 5E 5F 41 44 52  // [.RPXX.GMIO^_ADR
   1738E: 5F 41 44 52 0A 10                                // _ADR..

            Field (RPXX, AnyAcc, NoLock, Preserve)
            {
                VDID,   32
            }


   17394: 5B 81 0B 52 50 58 58 00 56 44 49 44 20           // [..RPXX.VDID 
```

Here is where VDID is used in a Switch statement, causing the parser error.
```
            Method (WIST, 0, Serialized)
            {

   173CD: 14 4A 14 57 49 53 54 08                          // .J.WIST.


   173D5: 08 5F 54 5F 30 00                                // ._T_0.

                If (CondRefOf (VDID))
                {

   173DB: A0 48 13 5B 12 56 44 49 44 00                    // .H.[.VDID.

                    Switch (ToInteger (VDID))
                    {

   173E5: A2 4E 12 01 70 99 56 44 49 44 00 5F 54 5F 30     // .N..p.VDID._T_0

                        Case (0x095A8086)
                        {

   173F4: A0 0D 93 5F 54 5F 30 0C 86 80 5A 09              // ..._T_0...Z.

                            Return (One)
                        }
```
