### PR TITLE
Ignore `MultiprocessorWakeup` when parse interrupt model

### DIFF
--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -282,6 +282,8 @@ impl Madt {
                     local_apic_address = entry.local_apic_address;
                 }
 
+                MadtEntry::MultiprocessorWakeup(_) => {}
+
                 _ => {
                     return Err(AcpiError::InvalidMadt(MadtError::UnexpectedEntry));
                 }


### PR DESCRIPTION
When parsing the interrupt model, including `MultiprocessorWakeup` in Madt will cause an error. We should ignore it.