### PR TITLE
Fix unsoundness in our representation of the MADT

### DIFF
--- a/acpi/src/handler.rs
+++ b/acpi/src/handler.rs
@@ -1,8 +1,4 @@
-use core::{
-    fmt,
-    ops::{Deref, DerefMut},
-    ptr::NonNull,
-};
+use core::{fmt, ops::Deref, pin::Pin, ptr::NonNull};
 
 /// Describes a physical mapping created by `AcpiHandler::map_physical_region` and unmapped by
 /// `AcpiHandler::unmap_physical_region`. The region mapped must be at least `size_of::<T>()`
@@ -73,6 +69,10 @@ where
         self.virtual_start
     }
 
+    pub fn get(&self) -> Pin<&T> {
+        unsafe { Pin::new_unchecked(self.virtual_start.as_ref()) }
+    }
+
     pub fn region_length(&self) -> usize {
         self.region_length
     }
@@ -90,6 +90,7 @@ unsafe impl<H: AcpiHandler + Send, T: Send> Send for PhysicalMapping<H, T> {}
 
 impl<H, T> Deref for PhysicalMapping<H, T>
 where
+    T: Unpin,
     H: AcpiHandler,
 {
     type Target = T;

--- a/acpi/src/platform/mod.rs
+++ b/acpi/src/platform/mod.rs
@@ -124,7 +124,7 @@ where
 
         let madt = tables.find_table::<Madt>();
         let (interrupt_model, processor_info) = match madt {
-            Ok(madt) => madt.parse_interrupt_model_in(allocator)?,
+            Ok(madt) => madt.get().parse_interrupt_model_in(allocator)?,
             Err(_) => (InterruptModel::Unknown, None),
         };
         let pm_timer = PmTimer::new(&fadt)?;

--- a/acpi/src/sdt.rs
+++ b/acpi/src/sdt.rs
@@ -197,7 +197,7 @@ impl SdtHeader {
 
         // This is usually redundant compared to simply calling `validate_checksum` but respects custom
         // `AcpiTable::validate` implementations.
-        table_mapping.validate()?;
+        table_mapping.get().validate()?;
 
         Ok(table_mapping)
     }


### PR DESCRIPTION
As reported in #218, we had a glaring soundness hole in the way we represented the MADT, which allowed an `Madt` to be moved away from its following entries. When `Madt::entries` was called, this would lead to arbitrary memory being read from after wherever the `Madt` ended up.

Moving the structures representing the tables is unlikely if the library is used as intended (and structures were `Copy` only because this was required by `repr(packed)`, but this is not actually required in the case of `Madt`), but this should obviously still be closed.

We make this sound by making `Madt: !Unpin`, which prevents the structure from being moved if in a `Pin`. To minimise difficulty using `PhysicalMapping`, we continue to allow mappings to deref to normal references if the underlying `T: Unpin`, but only allow access through `Pin<&T>` if `T: !Unpin` (ideally we'd just produce a `Pin` through deref but I don't think is possible?).

This feels like it should address the soundness issue from my end, but my knowledge surrounding `Pin` is still dubious at times, so anyone more knowledgeable who feels this is not correct please do let me know.

This would unfortunately be a breaking change.

cc @pyelias