### PR TITLE
Implement the multiprocessor wakeup mechanism.

### DIFF
--- a/acpi/src/handler.rs
+++ b/acpi/src/handler.rs
@@ -1,4 +1,8 @@
-use core::{fmt, ops::Deref, ptr::NonNull};
+use core::{
+    fmt,
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+};
 
 /// Describes a physical mapping created by `AcpiHandler::map_physical_region` and unmapped by
 /// `AcpiHandler::unmap_physical_region`. The region mapped must be at least `size_of::<T>()`
@@ -88,6 +92,15 @@ where
 
     fn deref(&self) -> &T {
         unsafe { self.virtual_start.as_ref() }
+    }
+}
+
+impl<H, T> DerefMut for PhysicalMapping<H, T>
+where
+    H: AcpiHandler,
+{
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { self.virtual_start.as_mut() }
     }
 }
 


### PR DESCRIPTION
[ACPI specification r6.4](https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#multiprocessor-wakeup-structure) introduced the Multiprocessor Wakeup Structure to let the bootstrap processor wake up application processors with a mailbox.

This PR follows the design and definition of ACPI specification and has been verified in my project.