### PR TITLE
acpi: Add method of rsdp from uefi and supports of several tables

### DIFF
--- a/acpi/Cargo.toml
+++ b/acpi/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 bit_field = "0.10.2"
 bitflags = "2.5.0"
 log = "0.4.20"
+uefi = "0.31.0"
 
 [features]
 default = ["allocator_api", "alloc"]

--- a/acpi/src/handler.rs
+++ b/acpi/src/handler.rs
@@ -76,6 +76,20 @@ where
     pub fn handler(&self) -> &H {
         &self.handler
     }
+
+    pub fn write<V>(&mut self, offset: usize, value: V) {
+        unsafe {
+            let ptr = (self.virtual_start.as_ptr() as *mut u8).add(offset) as *mut V;
+            ptr.write(value);
+        }
+    }
+
+    pub fn read<V>(&self, offset: usize) -> V {
+        unsafe {
+            let ptr = (self.virtual_start.as_ptr() as *mut u8).add(offset) as *mut V;
+            ptr.read()
+        }
+    }
 }
 
 unsafe impl<H: AcpiHandler + Send, T: Send> Send for PhysicalMapping<H, T> {}

--- a/acpi/src/iort.rs
+++ b/acpi/src/iort.rs
@@ -1,0 +1,236 @@
+///Apart from the basic header, the table contains a number of IORT Nodes. 
+/// Each node represents a component, which can be an SMMU, 
+/// an ITS Group, a root complex, or a component that is described in the namespace.
+use core::marker::PhantomData;
+use crate::{
+    sdt::{SdtHeader, Signature},
+    AcpiTable,
+};
+
+pub enum IortError {
+    
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct Iort {
+    header: SdtHeader,
+    node_number: u32,
+    node_array_offset: u32,
+    reserved: u32,
+    // After offset_to_node_array, there are node_number IORT Nodes
+}
+
+/// ### Safety: This is safe to implement.
+/// The IORT table is safe to implement because it is a valid ACPI table.
+unsafe impl AcpiTable for Iort {
+    const SIGNATURE: Signature = Signature::IORT;
+
+    fn header(&self) -> &SdtHeader {
+        &self.header
+    }
+}
+
+use core::fmt;
+impl fmt::Display for Iort {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "IORT: {:?}", self.header)?;
+        for node in self.nodes() {
+            write!(f, "\n{:#x?}", node)?
+        }
+        Ok(())
+    }
+}
+
+impl Iort {
+    pub fn nodes(&self) -> IortNodeIter {
+        let pointer = unsafe { (self as *const Iort).add(1) as *const u8 };
+        let remaining_length = self.header.length as u32 - size_of::<Iort>() as u32;
+
+        IortNodeIter {
+            pointer,
+            remaining_length,
+            _phantom: PhantomData
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct IortNodeHeader {
+    node_type: u8,
+    length: u16,
+    revision: u8,
+    identifier: u32,
+    pub id_mapping_num: u32,
+    pub id_mapping_array_offset: u32,
+    // Between this and id_mapping_array, there are data fields that are specific to each node type
+    // After offset_to_id_mapping_array, there are id_mapping_num ID Mappings
+}
+
+#[derive(Debug)]
+pub enum IortNode<'a> {
+    Its(&'a ItsNode),
+    NamedComponent(&'a NamedComponentNode),
+    RootComplex(&'a RootComplexNode),
+    SmmuV12(&'a SmmuV12Node),
+    SmmuV3(&'a SmmuV3Node),
+    Pmcg(&'a PmcgNode),
+    MemoryRange(&'a MemoryRangeNode),
+}
+
+impl IortNode {
+    pub fn id_mapping_array(&self) -> Option<&[IortIdMapping]> {
+        let id_mapping_num = unsafe {*(self as *const IortNode as *const IortNodeHeader).id_mapping_num};
+        let id_mapping_array_offset = unsafe {*(self as *const IortNode as *const IortNodeHeader).id_mapping_array_offset};
+        
+        if id_mapping_num == 0 {
+            return None;
+        } else {
+            unsafe {
+                let ptr = (self as *const IortNode as *const u8).add(id_mapping_array_offset as usize);
+                Some(core::slice::from_raw_parts(ptr as *const IortIdMapping, id_mapping_num as usize))
+            }
+        }
+    }
+}
+
+pub struct IortNodeIter<'a> {
+    pointer: *const u8,
+    remaining_length: u32,
+    _phantom: PhantomData<&'a ()>
+}
+
+impl<'a> Iterator for IortNodeIter<'a> {
+    type Item = IortNode<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining_length <= 0 {
+            return None;
+        }
+
+        let node = unsafe { &*(self.pointer as *const IortNodeHeader) };
+        let node_length = node.length as u32;
+
+        let node = match node.node_type {
+            0 => IortNode::Its(unsafe { &*(self.pointer as *const ItsNode) }),
+            1 => IortNode::NamedComponent(unsafe { &*(self.pointer as *const NamedComponentNode) }),
+            2 => IortNode::RootComplex(unsafe { &*(self.pointer as *const RootComplexNode) }),
+            3 => IortNode::SmmuV12(unsafe { &*(self.pointer as *const SmmuV12Node) }),
+            4 => IortNode::SmmuV3(unsafe { &*(self.pointer as *const SmmuV3Node) }),
+            5 => IortNode::Pmcg(unsafe { &*(self.pointer as *const PmcgNode) }),
+            6 => IortNode::MemoryRange(unsafe { &*(self.pointer as *const MemoryRangeNode) }),
+            _ => return None,
+        };
+
+        self.pointer = unsafe { self.pointer.add(node_length) };
+        self.remaining_length -= node_length as u32;
+
+        Some(node)
+    }
+}
+
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct ItsNode {
+    header: IortNodeHeader,
+    its_number: u32,
+    // This is followed by the ITS Identifer Array of length 4 * its_number
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct NamedComponentNode {
+    header: IortNodeHeader,
+    node_flags: u32,
+    mem_access_properties: u64,
+    device_mem_address_size_limit: u8,
+    // This is followed by a ASCII Null terminated string 
+    // with the full path to the entry in the namespace for this object
+    // and a padding to 32-bit word-aligned.
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct RootComplexNode {
+    header: IortNodeHeader,
+    mem_access_properties: u64,
+    ats_attribute: u32,
+    pci_segment_number: u32,
+    mem_address_size_limit: u8,
+    pasid_capabilities: u16,
+    reserved: u8,
+    flags: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct SmmuV12Node {
+    header: IortNodeHeader,
+    base_address: u64,
+    span: u64,
+    model: u32,
+    flags: u32,
+    global_interrupt_array_offset: u32,
+    context_interrupt_array_num: u32,
+    context_interrupt_array_offset: u32,
+    pmu_interrupt_array_num: u32,
+    pmu_interrupt_array_offset: u32,
+    // 后面是几个中断数组
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct SmmuV3Node {
+    header: IortNodeHeader,
+    base_address: u64,
+    flags: u32,
+    reserved: u32,
+    vatos_address: u64,
+    model: u32,
+    event: u32,
+    pri: u32,
+    gerr: u32,
+    sync: u32,
+    proximity_domain: u32,
+    device_id_mapping_index: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct PmcgNode {
+    header: IortNodeHeader,
+    pg0_base_address: u64,
+    overflow_interrupt: u32,
+    node_reference: u32,
+    pg1_base_address: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct MemoryRangeNode {
+    header: IortNodeHeader,
+    flags: u32,
+    mem_range_discriptor_array_num: u32,
+    mem_range_discriptor_array_offset: u32,
+    // After the base address of the node is offset, there are multiple MemoryRangeDescriptor
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct MemoryRangeDescriptor {
+    physical_range_offset: u64,
+    physical_range_length: u64,
+    reserved: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct IortIdMapping {
+    input_base: u32,
+    id_count: u32,
+    output_base: u32,
+    output_reference: u32,
+    flags: u32,
+}

--- a/acpi/src/iort.rs
+++ b/acpi/src/iort.rs
@@ -1,15 +1,13 @@
-///Apart from the basic header, the table contains a number of IORT Nodes. 
-/// Each node represents a component, which can be an SMMU, 
-/// an ITS Group, a root complex, or a component that is described in the namespace.
-use core::marker::PhantomData;
 use crate::{
     sdt::{SdtHeader, Signature},
     AcpiTable,
 };
+///Apart from the basic header, the table contains a number of IORT Nodes.
+/// Each node represents a component, which can be an SMMU,
+/// an ITS Group, a root complex, or a component that is described in the namespace.
+use core::marker::PhantomData;
 
-pub enum IortError {
-    
-}
+pub enum IortError {}
 
 #[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
@@ -47,11 +45,7 @@ impl Iort {
         let pointer = unsafe { (self as *const Iort).add(1) as *const u8 };
         let remaining_length = self.header.length as u32 - core::mem::size_of::<Iort>() as u32;
 
-        IortNodeIter {
-            pointer,
-            remaining_length,
-            _phantom: PhantomData
-        }
+        IortNodeIter { pointer, remaining_length, _phantom: PhantomData }
     }
 }
 
@@ -81,10 +75,10 @@ pub enum IortNode<'a> {
 
 impl IortNode<'_> {
     pub fn id_mapping_array(&self) -> Option<&[IortIdMapping]> {
-        let node_header = unsafe{ *(self as *const IortNode as *const IortNodeHeader) };
+        let node_header = unsafe { *(self as *const IortNode as *const IortNodeHeader) };
         let id_mapping_num = node_header.id_mapping_num;
         let id_mapping_array_offset = node_header.id_mapping_array_offset;
-        
+
         if id_mapping_num == 0 {
             return None;
         } else {
@@ -99,7 +93,7 @@ impl IortNode<'_> {
 pub struct IortNodeIter<'a> {
     pointer: *const u8,
     remaining_length: u32,
-    _phantom: PhantomData<&'a ()>
+    _phantom: PhantomData<&'a ()>,
 }
 
 impl<'a> Iterator for IortNodeIter<'a> {
@@ -131,7 +125,6 @@ impl<'a> Iterator for IortNodeIter<'a> {
     }
 }
 
-
 #[derive(Debug, Clone, Copy)]
 #[repr(C, packed)]
 pub struct ItsNode {
@@ -147,7 +140,7 @@ pub struct NamedComponentNode {
     node_flags: u32,
     mem_access_properties: u64,
     device_mem_address_size_limit: u8,
-    // This is followed by a ASCII Null terminated string 
+    // This is followed by a ASCII Null terminated string
     // with the full path to the entry in the namespace for this object
     // and a padding to 32-bit word-aligned.
 }

--- a/acpi/src/iort.rs
+++ b/acpi/src/iort.rs
@@ -43,7 +43,7 @@ impl fmt::Display for Iort {
 impl Iort {
     pub fn nodes(&self) -> IortNodeIter {
         let node_offset = self.node_array_offset as usize;
-        let pointer = unsafe { (self as *const Iort as *const u8).add(node_offset)};
+        let pointer = unsafe { (self as *const Iort as *const u8).add(node_offset) };
         let remaining_length = self.header.length as u32 - node_offset as u32;
 
         IortNodeIter { pointer, remaining_length, _phantom: PhantomData }

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -72,14 +72,14 @@ pub mod bgrt;
 pub mod fadt;
 pub mod handler;
 pub mod hpet;
+pub mod iort;
 pub mod madt;
 pub mod mcfg;
+pub mod mpam;
 pub mod rsdp;
 pub mod sdt;
 pub mod spcr;
 pub mod srat;
-pub mod mpam;
-pub mod iort;
 
 #[cfg(feature = "allocator_api")]
 mod managed_slice;

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -78,6 +78,7 @@ pub mod rsdp;
 pub mod sdt;
 pub mod spcr;
 pub mod srat;
+pub mod mpam;
 
 #[cfg(feature = "allocator_api")]
 mod managed_slice;

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -77,6 +77,7 @@ pub mod mcfg;
 pub mod rsdp;
 pub mod sdt;
 pub mod spcr;
+pub mod srat;
 
 #[cfg(feature = "allocator_api")]
 mod managed_slice;

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -58,6 +58,7 @@
 #![no_std]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(feature = "allocator_api", feature(allocator_api))]
+#![feature(ptr_from_ref)]
 
 #[cfg_attr(test, macro_use)]
 #[cfg(test)]

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -184,6 +184,12 @@ where
         unsafe { Self::from_validated_rsdp(handler, rsdp_mapping) }
     }
 
+    pub unsafe fn search_for_rsdp_uefi(handler: H, system_table: usize) -> AcpiResult<Self> {
+        let rsdp_mapping = unsafe { Rsdp::search_for_on_uefi(handler.clone(), system_table)? };
+        // Safety: RSDP has been validated from `Rsdp::search_for_on_uefi`
+        unsafe { Self::from_validated_rsdp(handler, rsdp_mapping) }
+    }
+
     /// Create an `AcpiTables` if you have a `PhysicalMapping` of the RSDP that you know is correct. This is called
     /// from `from_rsdp` after validation, but can also be used if you've searched for the RSDP manually on a BIOS
     /// system.

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -79,6 +79,7 @@ pub mod sdt;
 pub mod spcr;
 pub mod srat;
 pub mod mpam;
+pub mod iort;
 
 #[cfg(feature = "allocator_api")]
 mod managed_slice;

--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -124,20 +124,17 @@ impl Madt {
     where
         A: core::alloc::Allocator + Clone,
     {
-        use crate::{
-            platform::{
-                interrupt::{
-                    Apic,
-                    InterruptSourceOverride,
-                    IoApic,
-                    LocalInterruptLine,
-                    NmiLine,
-                    NmiProcessor,
-                    NmiSource,
-                },
-                processor::{ProcessorState, X86Processor},
+        use crate::platform::{
+            interrupt::{
+                Apic,
+                InterruptSourceOverride,
+                IoApic,
+                LocalInterruptLine,
+                NmiLine,
+                NmiProcessor,
+                NmiSource,
             },
-            AcpiError,
+            processor::{ProcessorState, X86Processor},
         };
 
         let mut local_apic_address = self.local_apic_address as u64;
@@ -332,12 +329,9 @@ impl Madt {
     where
         A: core::alloc::Allocator + Clone,
     {
-        use crate::{
-            platform::{
-                interrupt::{Gic, GicIts, GicMsiFrame, Gicc, Gicd, Gicr},
-                processor::Arm64Processor,
-            },
-            AcpiError,
+        use crate::platform::{
+            interrupt::{Gic, GicIts, GicMsiFrame, Gicc, Gicd, Gicr},
+            processor::Arm64Processor,
         };
 
         // need to count the number of each type of entry
@@ -404,6 +398,7 @@ impl Madt {
                         processor_uid: entry.processor_uid,
                         mpidr: entry.mpidr,
                         gicc_base_address: entry.gic_registers_address,
+                        gicr_base_address: entry.gicr_base_address,
                     };
                     gicc_count += 1;
                     processor_count += 1;

--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -375,8 +375,6 @@ impl Madt {
         for entry in self.entries() {
             match entry {
                 MadtEntry::Gicc(entry) => {
-                    // TODO the ProcessorInfo struct is not implemented for aaarch64 yet.
-                    // TODO need to implement the ProcessorInfo.
                     gicc[gicc_count] = Gicc {
                         cpu_interface_number: entry.cpu_interface_number,
                         acpi_processor_uid: entry.processor_uid,
@@ -394,7 +392,7 @@ impl Madt {
                         spe_overflow_interrupt: entry.spe_overflow_interrupt,
                     };
                     processors[processor_count] = Arm64Processor {
-                        processor_uid: entry.processor_uid as u32,
+                        processor_uid: entry.processor_uid,
                         mpidr: entry.mpidr,
                         gicc_base_address: entry.gic_registers_address,
                     };

--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -1,6 +1,5 @@
 use crate::{
-    sdt::{ExtendedField, SdtHeader, Signature},
-    AcpiTable,
+    sdt::{ExtendedField, SdtHeader, Signature}, AcpiTable
 };
 use bit_field::BitField;
 use core::{marker::PhantomData, mem};
@@ -9,7 +8,7 @@ use core::{marker::PhantomData, mem};
 use crate::{
     platform::{
         interrupt::{InterruptModel, Polarity, TriggerMode},
-        ProcessorInfo,
+        processor::ProcessorInfo,
     },
     AcpiResult,
 };
@@ -45,6 +44,17 @@ unsafe impl AcpiTable for Madt {
 
     fn header(&self) -> &SdtHeader {
         &self.header
+    }
+}
+
+use core::fmt;
+impl fmt::Display for Madt {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "MADT: {:#x?}", self.header)?;
+        for entry in self.entries() {
+            write!(f, "\n{:#x?}", entry)?
+        }
+        Ok(())
     }
 }
 
@@ -84,7 +94,7 @@ impl Madt {
                 MadtEntry::GicMsiFrame(_) |
                 MadtEntry::GicRedistributor(_) |
                 MadtEntry::GicInterruptTranslationService(_) => {
-                    unimplemented!();
+                    return self.parse_gic_model_in(allocator);
                 }
 
                 MadtEntry::MultiprocessorWakeup(_) => ()
@@ -113,8 +123,10 @@ impl Madt {
                     NmiProcessor,
                     NmiSource,
                 },
-                Processor,
-                ProcessorState,
+                processor::{
+                    X86Processor,
+                    ProcessorState,
+                }, 
             },
             AcpiError,
         };
@@ -145,14 +157,14 @@ impl Madt {
         let mut nmi_sources = crate::ManagedSlice::new_in(nmi_source_count, allocator.clone())?;
         let mut local_apic_nmi_lines = crate::ManagedSlice::new_in(local_nmi_line_count, allocator.clone())?;
         let mut application_processors =
-            crate::ManagedSlice::new_in(processor_count.saturating_sub(1), allocator)?; // Subtract one for the BSP
-        let mut boot_processor = None;
+            crate::ManagedSlice::new_in(processor_count, allocator)?; // Subtract one for the BSP
+        let mut found_bsp = false;
 
         io_apic_count = 0;
         iso_count = 0;
         nmi_source_count = 0;
         local_nmi_line_count = 0;
-        processor_count = 0;
+        processor_count = 1;
 
         for entry in self.entries() {
             match entry {
@@ -161,7 +173,7 @@ impl Madt {
                      * The first processor is the BSP. Subsequent ones are APs. If we haven't found
                      * the BSP yet, this must be it.
                      */
-                    let is_ap = boot_processor.is_some();
+                    let is_ap = found_bsp;
                     let is_disabled = !{ entry.flags }.get_bit(0);
 
                     let state = match (is_ap, is_disabled) {
@@ -170,7 +182,7 @@ impl Madt {
                         (false, false) => ProcessorState::Running,
                     };
 
-                    let processor = Processor {
+                    let processor = X86Processor {
                         processor_uid: entry.processor_id as u32,
                         local_apic_id: entry.apic_id as u32,
                         state,
@@ -181,12 +193,13 @@ impl Madt {
                         application_processors[processor_count] = processor;
                         processor_count += 1;
                     } else {
-                        boot_processor = Some(processor);
+                        application_processors[0] = processor;
+                        found_bsp = true;
                     }
                 }
 
                 MadtEntry::LocalX2Apic(entry) => {
-                    let is_ap = boot_processor.is_some();
+                    let is_ap = found_bsp;
                     let is_disabled = !{ entry.flags }.get_bit(0);
 
                     let state = match (is_ap, is_disabled) {
@@ -195,7 +208,7 @@ impl Madt {
                         (false, false) => ProcessorState::Running,
                     };
 
-                    let processor = Processor {
+                    let processor = X86Processor {
                         processor_uid: entry.processor_uid,
                         local_apic_id: entry.x2apic_id,
                         state,
@@ -206,7 +219,8 @@ impl Madt {
                         application_processors[processor_count] = processor;
                         processor_count += 1;
                     } else {
-                        boot_processor = Some(processor);
+                        application_processors[0] = processor;
+                        found_bsp = true;
                     }
                 }
 
@@ -297,8 +311,141 @@ impl Madt {
                 nmi_sources,
                 self.supports_8259(),
             )),
-            Some(ProcessorInfo::new(boot_processor.unwrap(), application_processors)),
+            Some(ProcessorInfo::new_x86(application_processors)),
         ))
+    }
+
+    fn parse_gic_model_in<'a, A>(
+        &self,
+        allocator: A,
+    ) -> AcpiResult<(InterruptModel<'a, A>, Option<ProcessorInfo<'a, A>>)>
+    where
+        A: core::alloc::Allocator + Clone,
+    {
+        use crate::{
+            platform::{
+                interrupt::{
+                    Gic,
+                    Gicd,
+                    Gicc,
+                    GicMsiFrame,
+                    Gicr,
+                    GicIts,
+                },
+                processor::Arm64Processor,
+            },
+            AcpiError,
+        };
+
+        // need to count the number of each type of entry
+
+        let mut gicc_count = 0;
+        let mut gicd_count = 0;
+        let mut gic_msi_frame_count = 0;
+        let mut gicr_count = 0;
+        let mut gic_its_count = 0;
+        let mut processor_count = 0;
+
+        for entry in self.entries() {
+            match entry {
+                MadtEntry::Gicc(_) => {gicc_count += 1; processor_count += 1;},
+                MadtEntry::Gicd(_) => gicd_count += 1,
+                MadtEntry::GicMsiFrame(_) => gic_msi_frame_count += 1,
+                MadtEntry::GicRedistributor(_) => gicr_count += 1,
+                MadtEntry::GicInterruptTranslationService(_) => gic_its_count += 1,
+                _ => (),
+            }
+        }
+
+        let mut gicc: crate::ManagedSlice<Gicc, A> = crate::ManagedSlice::new_in(gicc_count, allocator.clone())?;
+        let mut gicd: crate::ManagedSlice<Gicd, A> = crate::ManagedSlice::new_in(gicd_count, allocator.clone())?;
+        let mut gic_msi_frame: crate::ManagedSlice<GicMsiFrame, A> = crate::ManagedSlice::new_in(gic_msi_frame_count, allocator.clone())?;
+        let mut gicr: crate::ManagedSlice<Gicr, A> = crate::ManagedSlice::new_in(gicr_count, allocator.clone())?;
+        let mut gic_its: crate::ManagedSlice<GicIts, A> = crate::ManagedSlice::new_in(gic_its_count, allocator.clone())?;
+        let mut processors: crate::ManagedSlice<Arm64Processor, A> = crate::ManagedSlice::new_in(processor_count, allocator.clone())?;
+        // let mut boot_processor = None;
+
+        gicc_count = 0;
+        gicd_count = 0;
+        gic_msi_frame_count = 0;
+        gicr_count = 0;
+        gic_its_count = 0;
+        processor_count = 0;
+
+        for entry in self.entries() {
+            match entry {
+                MadtEntry::Gicc(entry) => {
+                    // TODO the ProcessorInfo struct is not implemented for aaarch64 yet.
+                    // TODO need to implement the ProcessorInfo.
+                    gicc[gicc_count] = Gicc {
+                        cpu_interface_number: entry.cpu_interface_number,
+                        acpi_processor_uid: entry.processor_uid,
+                        flags: entry.flags,
+                        parking_version: entry.parking_protocol_version,
+                        performance_interrupt_gsiv: entry.performance_interrupt_gsiv,
+                        parked_address: entry.parked_address,
+                        physical_base_address: entry.gic_registers_address,
+                        gicv: entry.gic_virtual_registers_address,
+                        gich: entry.gic_hypervisor_registers_address,
+                        vgic_maintenance_interrupt: entry.vgic_maintenance_interrupt,
+                        gicr_base_address: entry.gicr_base_address,
+                        mpidr: entry.mpidr,
+                        processor_power_efficiency_class: entry.processor_power_efficiency_class,
+                        spe_overflow_interrupt: entry.spe_overflow_interrupt,
+                    };
+                    processors[processor_count] = Arm64Processor {
+                        processor_uid: entry.processor_uid as u32,
+                        mpidr: entry.mpidr,
+                        gicc_base_address: entry.gic_registers_address,
+                    };
+                    gicc_count += 1;
+                    processor_count += 1;
+                }
+                MadtEntry::Gicd(entry) => {
+                    gicd[gicd_count] = Gicd {
+                        id: entry.gic_id,
+                        physical_base_address: entry.physical_base_address,
+                        gic_version: entry.gic_version,
+                    };
+                    gicd_count += 1;
+                }
+                MadtEntry::GicMsiFrame(entry) => {
+                    gic_msi_frame[gic_msi_frame_count] = GicMsiFrame {
+                        id: entry.frame_id,
+                        physical_base_address: entry.physical_base_address,
+                        spi_count_base_select: { entry.flags }.get_bit(0),
+                        spi_count: entry.spi_count,
+                        spi_base: entry.spi_base,
+                    };
+                    gic_msi_frame_count += 1;
+                }
+                MadtEntry::GicRedistributor(entry) => {
+                    gicr[gicr_count] = Gicr {
+                        base_address: entry.discovery_range_base_address,
+                        length: entry.discovery_range_length,
+                    };
+                    gicr_count += 1;
+                }
+                MadtEntry::GicInterruptTranslationService(entry) => {
+                    gic_its[gic_its_count] = GicIts {
+                        id: entry.id,
+                        physical_base_address: entry.physical_base_address,
+                    };
+                    gic_its_count += 1;
+                }
+                _ => {
+                    return Err(AcpiError::InvalidMadt(MadtError::UnexpectedEntry));
+                },
+            }
+        }
+
+        Ok((InterruptModel::Gic(Gic::new(
+            gicc,
+            gicd,
+            gic_msi_frame,
+            gicr,
+            gic_its,
+        )), Some(ProcessorInfo::new_arm64(processors))))
     }
 
     pub fn entries(&self) -> MadtEntryIter {

--- a/acpi/src/mpam.rs
+++ b/acpi/src/mpam.rs
@@ -1,0 +1,209 @@
+use core::{marker::PhantomData, mem::size_of};
+
+use crate::{
+    sdt::{SdtHeader, Signature},
+    AcpiTable,
+};
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct Mpam {
+    header: SdtHeader,
+    // An array of MPAM node structures that describes MSCs in the system.
+}
+
+/// ### Safety: This is safe to implement.
+unsafe impl AcpiTable for Mpam {
+    const SIGNATURE: Signature = Signature::MPAM;
+
+    fn header(&self) -> &SdtHeader {
+        &self.header
+    }
+}
+
+use core::fmt;
+impl fmt::Display for Mpam {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MAPM: {:#x?}", self.header)?;
+        let mut i = 100;
+        for node in self.nodes() {
+            write!(f, "\n{:#x?}", node)?;
+            i -= 1;
+            if i == 0 {
+                break;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Mpam {
+    /// Returns an iterator over the MPAM node structures.
+    pub fn nodes(&self) -> MscNodeIter {
+        let pointer = unsafe { (self as *const Mpam).add(1) as *const u8 };
+        let remaining_length = self.header.length as u32 - size_of::<Mpam>() as u32;
+
+        MscNodeIter {
+            pointer,
+            remaining_length,
+            _phantom: PhantomData
+        }
+    }
+
+    pub fn mmio_ranges(&self) -> impl Iterator<Item = (u64, u32)> + '_ {
+        self.nodes().filter_map(|node| {
+            return if node.if_type == 0x00 {
+                Some((node.base_address, node.mmio_size))
+            } else {
+                None
+            };
+        })
+    }
+}
+
+pub struct MscNodeIter<'a> {
+    pointer: *const u8,
+    remaining_length: u32,
+    _phantom: PhantomData<&'a ()>
+}
+
+impl Iterator for MscNodeIter<'_> {
+    type Item = MscNode;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining_length <= 0 {
+            return None;
+        }
+
+        let node = unsafe { &*(self.pointer as *const MscNode) };
+        let node_length = node.length as u32;
+        
+        self.pointer = unsafe { self.pointer.add(node_length as usize) };
+        self.remaining_length -= node_length;
+
+        Some(*node)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct MscNode {
+    // MPAM node structure
+    pub length: u16,
+    pub if_type: u8,
+    pub reserved: u8,
+    pub id: u32,
+    pub base_address: u64,
+    pub mmio_size: u32,
+    
+    pub overflow_interrupt: u32,
+    pub overflow_interrupt_flags: u32,
+    pub reserved2: u32,
+    pub overflow_interrupt_affinity: u32,
+    
+    pub error_interrupt: u32,
+    pub error_interrupt_flags: u32,
+    pub reserved3: u32,
+    pub error_interrupt_affinity: u32,
+
+    pub max_nrdy_usec: u32,
+    pub hw_id: u64,
+    pub instance_id: u32,
+    pub resource_node_num: u32,
+    // Resource node list
+    // after the resource node list, there is resource specific data, if the length after the resource node list is not 0
+}
+
+impl fmt::Display for MscNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#x?}", self)?;
+        for node in self.resource_nodes() {
+            write!(f, "\n\t{}", node)?
+        }
+        Ok(())
+    }
+}
+
+impl MscNode {
+    pub fn resource_nodes(&self) -> ResourceNodeIter {
+        let ptr = unsafe {
+            let ptr = self as *const MscNode;
+            ptr.add(1) as *const u8
+        };
+        let remaining_length = self.length as u32 - size_of::<MscNode>() as u32;
+        ResourceNodeIter {
+            pointer: ptr,
+            remaining_length,
+            remaining_nodes: self.resource_node_num,
+            _phantom: PhantomData
+        }
+    }
+}
+
+pub struct ResourceNodeIter<'a> {
+    pointer: *const u8,
+    remaining_length: u32,
+    remaining_nodes: u32,
+    _phantom: PhantomData<&'a ()>
+}
+
+impl Iterator for ResourceNodeIter<'_> {
+    type Item = ResourceNode;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining_length <= 0 || self.remaining_nodes <= 0 {
+            return None;
+        }
+
+        let node = unsafe { &*(self.pointer as *const ResourceNode) };
+        let node_length = size_of::<ResourceNode>() + (node.func_dep_num as usize) * size_of::<FunctionDependency>();
+        
+        self.pointer = unsafe { self.pointer.add(node_length) };
+        self.remaining_length -= node_length as u32;
+        self.remaining_nodes -= 1;
+
+        Some(*node)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct ResourceNode {
+    // Resource node structure
+    pub id: u32,
+    pub ris_id: u32,
+    pub reserved: u16,
+    pub locator_type: u8,
+    pub locator: (u64, u32),
+    pub func_dep_num: u32,
+    // Function dependency list [FunctionDependency]
+}
+
+impl fmt::Display for ResourceNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#x?}", self)?;
+        for dep in self.function_dependencies() {
+            write!(f, "\n\t{:#x?}", dep)?
+        }
+        Ok(())
+    }
+}
+
+impl ResourceNode {
+    pub fn function_dependencies(&self) -> &[FunctionDependency] {
+        let ptr = self as *const ResourceNode;
+        let ptr = unsafe { ptr.add(1) };
+        let ptr = ptr as *const FunctionDependency;
+        unsafe {
+            core::slice::from_raw_parts(ptr, self.func_dep_num as usize)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct FunctionDependency {
+    // Function dependency structure
+    pub producer: u32,
+    pub reserved: u32,
+}

--- a/acpi/src/mpam.rs
+++ b/acpi/src/mpam.rs
@@ -43,20 +43,12 @@ impl Mpam {
         let pointer = unsafe { (self as *const Mpam).add(1) as *const u8 };
         let remaining_length = self.header.length as u32 - size_of::<Mpam>() as u32;
 
-        MscNodeIter {
-            pointer,
-            remaining_length,
-            _phantom: PhantomData
-        }
+        MscNodeIter { pointer, remaining_length, _phantom: PhantomData }
     }
 
     pub fn mmio_ranges(&self) -> impl Iterator<Item = (u64, u32)> + '_ {
         self.nodes().filter_map(|node| {
-            return if node.if_type == 0x00 {
-                Some((node.base_address, node.mmio_size))
-            } else {
-                None
-            };
+            return if node.if_type == 0x00 { Some((node.base_address, node.mmio_size)) } else { None };
         })
     }
 }
@@ -64,7 +56,7 @@ impl Mpam {
 pub struct MscNodeIter<'a> {
     pointer: *const u8,
     remaining_length: u32,
-    _phantom: PhantomData<&'a ()>
+    _phantom: PhantomData<&'a ()>,
 }
 
 impl Iterator for MscNodeIter<'_> {
@@ -77,7 +69,7 @@ impl Iterator for MscNodeIter<'_> {
 
         let node = unsafe { &*(self.pointer as *const MscNode) };
         let node_length = node.length as u32;
-        
+
         self.pointer = unsafe { self.pointer.add(node_length as usize) };
         self.remaining_length -= node_length;
 
@@ -95,12 +87,12 @@ pub struct MscNode {
     pub id: u32,
     pub base_address: u64,
     pub mmio_size: u32,
-    
+
     pub overflow_interrupt: u32,
     pub overflow_interrupt_flags: u32,
     pub reserved2: u32,
     pub overflow_interrupt_affinity: u32,
-    
+
     pub error_interrupt: u32,
     pub error_interrupt_flags: u32,
     pub reserved3: u32,
@@ -135,7 +127,7 @@ impl MscNode {
             pointer: ptr,
             remaining_length,
             remaining_nodes: self.resource_node_num,
-            _phantom: PhantomData
+            _phantom: PhantomData,
         }
     }
 }
@@ -144,7 +136,7 @@ pub struct ResourceNodeIter<'a> {
     pointer: *const u8,
     remaining_length: u32,
     remaining_nodes: u32,
-    _phantom: PhantomData<&'a ()>
+    _phantom: PhantomData<&'a ()>,
 }
 
 impl Iterator for ResourceNodeIter<'_> {
@@ -156,8 +148,9 @@ impl Iterator for ResourceNodeIter<'_> {
         }
 
         let node = unsafe { &*(self.pointer as *const ResourceNode) };
-        let node_length = size_of::<ResourceNode>() + (node.func_dep_num as usize) * size_of::<FunctionDependency>();
-        
+        let node_length =
+            size_of::<ResourceNode>() + (node.func_dep_num as usize) * size_of::<FunctionDependency>();
+
         self.pointer = unsafe { self.pointer.add(node_length) };
         self.remaining_length -= node_length as u32;
         self.remaining_nodes -= 1;
@@ -194,9 +187,7 @@ impl ResourceNode {
         let ptr = self as *const ResourceNode;
         let ptr = unsafe { ptr.add(1) };
         let ptr = ptr as *const FunctionDependency;
-        unsafe {
-            core::slice::from_raw_parts(ptr, self.func_dep_num as usize)
-        }
+        unsafe { core::slice::from_raw_parts(ptr, self.func_dep_num as usize) }
     }
 }
 

--- a/acpi/src/mpam.rs
+++ b/acpi/src/mpam.rs
@@ -25,13 +25,8 @@ use core::fmt;
 impl fmt::Display for Mpam {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "MAPM: {:#x?}", self.header)?;
-        let mut i = 100;
         for node in self.nodes() {
             write!(f, "\n{:#x?}", node)?;
-            i -= 1;
-            if i == 0 {
-                break;
-            }
         }
         Ok(())
     }

--- a/acpi/src/platform/interrupt.rs
+++ b/acpi/src/platform/interrupt.rs
@@ -117,6 +117,88 @@ where
 }
 
 #[derive(Debug)]
+pub struct Gicc {
+    pub cpu_interface_number: u32,
+    pub acpi_processor_uid: u32,
+    pub flags: u32,
+
+    pub parking_version: u32,
+    pub performance_interrupt_gsiv: u32,
+    pub parked_address: u64,
+
+    pub physical_base_address: u64,
+    pub gicv: u64,
+    pub gich: u64,
+    pub vgic_maintenance_interrupt: u32,
+    pub gicr_base_address: u64,
+
+    pub mpidr: u64,
+    pub processor_power_efficiency_class: u8,
+    pub spe_overflow_interrupt: u16,
+}
+
+#[derive(Debug)]
+pub struct Gicd {
+    pub id: u32,
+    pub physical_base_address: u64,
+    pub gic_version: u8,
+}
+
+#[derive(Debug)]
+pub struct GicMsiFrame {
+    pub id: u32,
+    pub physical_base_address: u64,
+    pub spi_count_base_select: bool,
+    pub spi_count: u16,
+    pub spi_base: u16,
+}
+
+#[derive(Debug)]
+pub struct Gicr {
+    pub base_address: u64,
+    pub length: u32,
+}
+
+#[derive(Debug)]
+pub struct GicIts {
+    pub id: u32,
+    pub physical_base_address: u64,
+}
+
+#[derive(Debug)]
+pub struct Gic<'a, A>
+where
+    A: Allocator,
+{
+    pub gicc: ManagedSlice<'a, Gicc, A>,
+    pub gicd: ManagedSlice<'a, Gicd, A>,
+    pub gic_msi_frame: ManagedSlice<'a, GicMsiFrame, A>,
+    pub gicr: ManagedSlice<'a, Gicr, A>,
+    pub gic_its: ManagedSlice<'a, GicIts, A>,
+}
+
+impl<'a, A> Gic<'a, A>
+where
+    A: Allocator,
+{
+    pub(crate) fn new(
+        gicc: ManagedSlice<'a, Gicc, A>,
+        gicd: ManagedSlice<'a, Gicd, A>,
+        gic_msi_frame: ManagedSlice<'a, GicMsiFrame, A>,
+        gicr: ManagedSlice<'a, Gicr, A>,
+        gic_its: ManagedSlice<'a, GicIts, A>,
+    ) -> Self {
+        Self {
+            gicc,
+            gicd,
+            gic_msi_frame,
+            gicr,
+            gic_its,
+        }
+    }
+}
+
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum InterruptModel<'a, A>
 where
@@ -130,4 +212,6 @@ where
     /// XAPIC, or X2APIC). These are likely to be found on x86 and x86_64 systems and are made up of a Local APIC
     /// for each core and one or more I/O APICs to handle external interrupts.
     Apic(Apic<'a, A>),
+
+    Gic(Gic<'a, A>),
 }

--- a/acpi/src/platform/interrupt.rs
+++ b/acpi/src/platform/interrupt.rs
@@ -188,13 +188,7 @@ where
         gicr: ManagedSlice<'a, Gicr, A>,
         gic_its: ManagedSlice<'a, GicIts, A>,
     ) -> Self {
-        Self {
-            gicc,
-            gicd,
-            gic_msi_frame,
-            gicr,
-            gic_its,
-        }
+        Self { gicc, gicd, gic_msi_frame, gicr, gic_its }
     }
 }
 

--- a/acpi/src/platform/processor.rs
+++ b/acpi/src/platform/processor.rs
@@ -32,6 +32,8 @@ pub struct Arm64Processor {
     /// this field holds the 64-bit physical address at which the processor can access this GIC CPU Interface.
     /// If provided here, the “Local Interrupt Controller Address” field in the MADT must be ignored by the OSPM.
     pub gicc_base_address: u64,
+    /// On GICv3/4 systems, this field holds the 64-bit physical address at which the processor can access this GIC Redistributor.
+    pub gicr_base_address: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/acpi/src/platform/processor.rs
+++ b/acpi/src/platform/processor.rs
@@ -28,7 +28,8 @@ pub struct Arm64Processor {
     pub processor_uid: u32,
     /// This fields follows the MPIDR formatting of ARM architecture.
     pub mpidr: u64,
-    /// On GICv1/v2 systems and GICv3/4 systems in GICv2 compatibility mode, this field holds the 64-bit physical address at which the processor can access this GIC CPU Interface.
+    /// On GICv1/v2 systems and GICv3/4 systems in GICv2 compatibility mode,
+    /// this field holds the 64-bit physical address at which the processor can access this GIC CPU Interface.
     /// If provided here, the “Local Interrupt Controller Address” field in the MADT must be ignored by the OSPM.
     pub gicc_base_address: u64,
 }

--- a/acpi/src/platform/processor.rs
+++ b/acpi/src/platform/processor.rs
@@ -1,0 +1,91 @@
+use crate::ManagedSlice;
+use core::alloc::Allocator;
+
+/// Processor trait
+pub trait Processor {
+    /// The OS associates this GICC Structure with a processor device object in the namespace 
+    /// when the _UID child object of the processor device evaluates to a numeric value that matches the numeric value in this field.
+    fn processor_uid(&self) -> u32;
+}
+
+impl Processor for Arm64Processor {
+    fn processor_uid(&self) -> u32 {
+        self.processor_uid
+    }
+}
+
+impl Processor for X86Processor {
+    fn processor_uid(&self) -> u32 {
+        self.processor_uid
+    }
+}
+
+/// Arm64 processor
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Arm64Processor {
+    /// The OS associates this GICC Structure with a processor device object in the namespace 
+    /// when the _UID child object of the processor device evaluates to a numeric value that matches the numeric value in this field.
+    pub processor_uid: u32,
+    /// This fields follows the MPIDR formatting of ARM architecture.
+    pub mpidr: u64,
+    /// On GICv1/v2 systems and GICv3/4 systems in GICv2 compatibility mode, this field holds the 64-bit physical address at which the processor can access this GIC CPU Interface.
+    /// If provided here, the “Local Interrupt Controller Address” field in the MADT must be ignored by the OSPM.
+    pub gicc_base_address: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProcessorState {
+    /// A processor in this state is unusable, and you must not attempt to bring it up.
+    Disabled,
+
+    /// A processor waiting for a SIPI (Startup Inter-processor Interrupt) is currently not active,
+    /// but may be brought up.
+    WaitingForSipi,
+
+    /// A Running processor is currently brought up and running code.
+    Running,
+}
+
+/// x86_64 processor
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct X86Processor {
+    /// Corresponds to the `_UID` object of the processor's `Device`, or the `ProcessorId` field of the `Processor`
+    /// object, in AML.
+    pub processor_uid: u32,
+    /// The ID of the local APIC of the processor. Will be less than `256` if the APIC is being used, but can be
+    /// greater than this if the X2APIC is being used.
+    pub local_apic_id: u32,
+
+    /// The state of this processor. Check that the processor is not `Disabled` before attempting to bring it up!
+    pub state: ProcessorState,
+
+    /// Whether this processor is the Bootstrap Processor (BSP), or an Application Processor (AP).
+    /// When the bootloader is entered, the BSP is the only processor running code. To run code on
+    /// more than one processor, you need to "bring up" the APs.
+    pub is_ap: bool,
+}
+
+#[derive(Debug)]
+pub enum ProcessorInfo<'a, A>
+where
+    A: Allocator,
+{
+    /// in x86_64, the BSP is the first processor.
+    /// Application processors should be brought up in the order they're defined in this list.
+    X86Processors(ManagedSlice<'a, X86Processor, A>),
+
+    Arm64Processors(ManagedSlice<'a, Arm64Processor, A>),
+}
+
+impl<'a, A> ProcessorInfo<'a, A>
+where
+    A: Allocator,
+{
+    pub fn new_x86(processors: ManagedSlice<'a, X86Processor, A>) -> Self {
+        ProcessorInfo::X86Processors(processors)
+    }
+
+    pub fn new_arm64(processors: ManagedSlice<'a, Arm64Processor, A>) -> Self {
+        ProcessorInfo::Arm64Processors(processors)
+    }
+}

--- a/acpi/src/platform/processor.rs
+++ b/acpi/src/platform/processor.rs
@@ -3,7 +3,7 @@ use core::alloc::Allocator;
 
 /// Processor trait
 pub trait Processor {
-    /// The OS associates this GICC Structure with a processor device object in the namespace 
+    /// The OS associates this GICC Structure with a processor device object in the namespace
     /// when the _UID child object of the processor device evaluates to a numeric value that matches the numeric value in this field.
     fn processor_uid(&self) -> u32;
 }
@@ -23,7 +23,7 @@ impl Processor for X86Processor {
 /// Arm64 processor
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Arm64Processor {
-    /// The OS associates this GICC Structure with a processor device object in the namespace 
+    /// The OS associates this GICC Structure with a processor device object in the namespace
     /// when the _UID child object of the processor device evaluates to a numeric value that matches the numeric value in this field.
     pub processor_uid: u32,
     /// This fields follows the MPIDR formatting of ARM architecture.

--- a/acpi/src/rsdp.rs
+++ b/acpi/src/rsdp.rs
@@ -1,7 +1,7 @@
 use uefi::table::{cfg::ACPI2_GUID, Boot, SystemTable};
 
 use crate::{AcpiError, AcpiHandler, AcpiResult, PhysicalMapping};
-use core::{mem, ops::Range, slice, str, ffi::c_void};
+use core::{ffi::c_void, mem, ops::Range, slice, str};
 
 /// The size in bytes of the ACPI 1.0 RSDP.
 const RSDP_V1_LENGTH: usize = 20;
@@ -112,14 +112,13 @@ impl Rsdp {
     where
         H: AcpiHandler,
     {
-        let system_table = unsafe {
-            SystemTable::<Boot>::from_ptr(system_table as *mut c_void).unwrap()
-        };
+        let system_table = unsafe { SystemTable::<Boot>::from_ptr(system_table as *mut c_void).unwrap() };
 
         let config_table = system_table.config_table();
         let rsdp = config_table.iter().find_map(|entry| {
             if entry.guid == ACPI2_GUID {
-                let rsdp_mapping = unsafe { handler.map_physical_region::<Rsdp>(entry.address as usize, mem::size_of::<Rsdp>()) };
+                let rsdp_mapping =
+                    unsafe { handler.map_physical_region::<Rsdp>(entry.address as usize, mem::size_of::<Rsdp>()) };
                 match rsdp_mapping.validate() {
                     Ok(()) => Some(rsdp_mapping),
                     Err(AcpiError::RsdpIncorrectSignature) => None,

--- a/acpi/src/srat.rs
+++ b/acpi/src/srat.rs
@@ -1,0 +1,179 @@
+use core::marker::PhantomData;
+
+use crate::{
+    sdt::{SdtHeader, Signature},
+    AcpiTable,
+};
+
+pub enum SratError {
+    
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct Srat {
+    header: SdtHeader,
+    _reserved: u32,
+    _reserved2: u64,
+    // Followed by `n` structs with Static Resource Allocation Structure
+    // A list of static resource allocation structures for the platform. 
+    // See Processor Local APIC/SAPIC Affinity Structure, Memory Affinity Structure, 
+    // Processor Local x2APIC Affinity Structure, and GICC Affinity Structure.
+}
+
+/// ### Safety: Implementation properly represents a valid SRAT.
+unsafe impl AcpiTable for Srat {
+    const SIGNATURE: Signature = Signature::SRAT;
+
+    fn header(&self) -> &SdtHeader {
+        &self.header
+    }
+}
+
+use core::fmt;
+impl fmt::Display for Srat {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SRAT: {:?}", self.header)?;
+        for entry in self.entries() {
+            write!(f, "\n{:#x?}", entry)?
+        }
+        Ok(())
+    }
+}
+
+impl Srat {
+    pub fn entries(&self) -> AffinityStructIter {
+        let pointer = unsafe { (self as *const Srat).add(1) as *const u8 };
+        let remaining_length = self.header.length as u32 - core::mem::size_of::<Srat>() as u32;
+
+        AffinityStructIter {
+            pointer,
+            remaining_length,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct AffinityStructIter<'a> {
+    pointer: *const u8,
+    
+    remaining_length: u32,
+    _phantom: PhantomData<&'a ()>
+}
+
+#[derive(Debug)]
+pub enum AffinityStruct<'a> {
+    LocalApicAffinity(&'a LocalApicAffinity),
+    MemoryAffinity(&'a MemoryAffinity),
+    LocalX2ApicAffinity(&'a LocalX2ApicAffinity),
+    GiccAffinity(&'a GiccAffinity),
+    GicItsAffinity(&'a GicItsAffinity),
+    GenericInitiatorAffinity(&'a GenericInitiatorAffinity),
+}
+
+impl<'a> Iterator for AffinityStructIter<'a> {
+    type Item = AffinityStruct<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining_length <= 0 {
+            return None;
+        }
+
+        let struct_header = unsafe { &*(self.pointer as *const StructHeader) };
+        let struct_length = struct_header.length as u32;
+        let struct_type = struct_header.struct_type;
+
+        let affinity_struct = match struct_type {
+            0 => AffinityStruct::LocalApicAffinity(unsafe { &*(self.pointer as *const LocalApicAffinity) }),
+            1 => AffinityStruct::MemoryAffinity(unsafe { &*(self.pointer as *const MemoryAffinity) }),
+            2 => AffinityStruct::LocalX2ApicAffinity(unsafe { &*(self.pointer as *const LocalX2ApicAffinity) }),
+            3 => AffinityStruct::GiccAffinity(unsafe { &*(self.pointer as *const GiccAffinity) }),
+            4 => AffinityStruct::GicItsAffinity(unsafe { &*(self.pointer as *const GicItsAffinity) }),
+            5 => AffinityStruct::GenericInitiatorAffinity(unsafe { &*(self.pointer as *const GenericInitiatorAffinity) }),
+            _ => return None,
+        };
+
+        self.pointer = unsafe { self.pointer.add(struct_length as usize) };
+        self.remaining_length -= struct_length;
+
+        Some(affinity_struct)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct StructHeader {
+    pub struct_type: u8,
+    pub length: u8,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct LocalApicAffinity {
+    pub struct_header: StructHeader,
+    pub proximity_domain_lo: u8,
+    pub apic_id: u8,
+    pub flags: u32,
+    pub local_sapic_eid: u8,
+    pub proximity_domain_hi: [u8; 3],
+    pub clock_domain: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct MemoryAffinity {
+    pub struct_header: StructHeader,
+    pub proximity_domain: u32,
+    pub _reserved: u16,
+    pub base_address_lo: u32,
+    pub base_address_hi: u32,
+    pub length_lo: u32,
+    pub length_hi: u32,
+    pub _reserved2: u32,
+    pub flags: u32,
+    pub _reserved3: [u8; 8],
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct LocalX2ApicAffinity {
+    pub struct_header: StructHeader,
+    pub _reserved: u16,
+    pub proximity_domain: u32,
+    pub x2apic_id: u32,
+    pub flags: u32,
+    pub clock_domain: u32,
+    pub _reserved2: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct GiccAffinity {
+    pub struct_header: StructHeader,
+    pub proximity_domain: u32,
+    pub acpi_processor_uid: u32,
+    pub flags: u32,
+    pub clock_domain: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct GicItsAffinity {
+    pub struct_header: StructHeader,
+    pub proximity_domain: u32,
+    pub _reserved: u16,
+    pub its_id: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct GenericInitiatorAffinity {
+    pub struct_header: StructHeader,
+    pub _reserved: u8,
+    pub device_handle_type: u8,
+    pub proximity_domain: u32,
+    pub device_handle: [u8; 16],
+    pub flags: u32,
+    pub _reserved2: u32,
+}

--- a/aml/src/name_object.rs
+++ b/aml/src/name_object.rs
@@ -173,7 +173,7 @@ where
 pub struct NameSeg(pub(crate) [u8; 4]);
 
 impl NameSeg {
-    pub(crate) fn from_str(string: &str) -> Result<NameSeg, AmlError> {
+    pub fn from_str(string: &str) -> Result<NameSeg, AmlError> {
         // Each NameSeg can only have four chars, and must have at least one
         if string.len() < 1 || string.len() > 4 {
             return Err(AmlError::InvalidNameSeg);

--- a/aml/src/opregion.rs
+++ b/aml/src/opregion.rs
@@ -9,9 +9,9 @@ use bit_field::BitField;
 
 #[derive(Clone, Debug)]
 pub struct OpRegion {
-    region: RegionSpace,
-    base: u64,
-    length: u64,
+    pub region: RegionSpace,
+    pub base: u64,
+    pub length: u64,
     parent_device: Option<AmlName>,
 }
 

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -264,7 +264,7 @@ impl AmlValue {
         match self {
             AmlValue::Boolean(value) => Ok(*value),
             AmlValue::Integer(value) => Ok(*value != 0),
-            AmlValue::Field{ .. } => Ok(self.as_integer(context)? != 0),
+            AmlValue::Field { .. } => Ok(self.as_integer(context)? != 0),
             _ => Err(AmlError::IncompatibleValueConversion { current: self.type_of(), target: AmlType::Integer }),
         }
     }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2023-11-09"
+components = ["rust-src", "llvm-tools-preview"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly-2023-11-09"
-components = ["rust-src", "llvm-tools-preview"]


### PR DESCRIPTION
I am developing an aarch64 hypervisor and need to use this ACPI lib. During this process, I have made many modifications and improvements to it, as follows:
1. Added method to get RSDP from UEFI firmware.
2. Added support for SRAT, IORT, MPAM, and other tables.
3. Added information of ARM interrupt model GIC obtained through MADT.

The current project has not yet been completed, so this PR will continue to improve. But also due to the tight progress of the project, there are many irregularities in the code now. I will fix them one by one in my spare time. If you have any requirements, please feel free to ask.