### PR TITLE
acpi-dumper: fix invocation of compile_error!

### DIFF
--- a/acpi-dumper/src/main.rs
+++ b/acpi-dumper/src/main.rs
@@ -98,5 +98,5 @@ fn main() {
 
 #[cfg(not(target_os = "linux"))]
 fn main() {
-    std::compilation_error!("acpi-dumper currently only supports linux");
+    std::compile_error!("acpi-dumper currently only supports linux");
 }


### PR DESCRIPTION
I got this error when running `cargo test` on a Mac host:

```
error[E0433]: failed to resolve: could not find `compilation_error` in `std`
   --> acpi-dumper/src/main.rs:101:10
    |
101 |     std::compilation_error!("acpi-dumper currently only supports linux");
    |          ^^^^^^^^^^^^^^^^^ could not find `compilation_error` in `std`
```

This PR fixes the typo.