### PR TITLE
acpi: fix clippy warnings and run clippy in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,3 +64,20 @@ jobs:
 
     - name: Run AML test suite
       run: cargo run --bin aml_tester -- -p tests --reset
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        default: true
+        profile: minimal
+        components: clippy
+
+    - name: Run clippy
+      run: cargo clippy -p acpi

--- a/acpi/src/handler.rs
+++ b/acpi/src/handler.rs
@@ -51,6 +51,10 @@ where
     ///   than `region_length`, due to requirements of the paging system or other reasoning.
     /// - `handler` should be the same `AcpiHandler` that created the mapping. When the `PhysicalMapping` is
     ///   dropped, it will be used to unmap the structure.
+    ///
+    /// ### Safety
+    ///
+    /// The caller must ensure that the physical memory can be safely mapped.
     pub unsafe fn new(
         physical_start: usize,
         virtual_start: NonNull<T>,

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -28,7 +28,7 @@
 //! * Use `AcpiTables::from_rsdp` if you have the physical address of the RSDP
 //! * Use `AcpiTables::from_rsdt` if you have the physical address of the RSDT/XSDT
 //! * Use `AcpiTables::search_for_rsdp_bios` if you don't have the address of either, but **you know you are
-//! running on BIOS, not UEFI**
+//!   running on BIOS, not UEFI**
 //!
 //! `AcpiTables` stores the addresses of all of the tables detected on a platform. The SDTs are parsed by this
 //! library, or can be accessed directly with `from_sdt`, while the `DSDT` and any `SSDTs` should be parsed with

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -200,7 +200,9 @@ where
 {
     /// Create an `AcpiTables` if you have the physical address of the RSDP.
     ///
-    /// ### Safety: Caller must ensure the provided address is valid to read as an RSDP.
+    /// ### Safety
+    ///
+    /// Caller must ensure the provided address is valid to read as an RSDP.
     pub unsafe fn from_rsdp(handler: H, address: usize) -> AcpiResult<Self> {
         let rsdp_mapping = unsafe { handler.map_physical_region::<Rsdp>(address, mem::size_of::<Rsdp>()) };
         rsdp_mapping.validate()?;
@@ -212,6 +214,10 @@ where
     /// Search for the RSDP on a BIOS platform. This accesses BIOS-specific memory locations and will probably not
     /// work on UEFI platforms. See [Rsdp::search_for_rsdp_bios](rsdp_search::Rsdp::search_for_rsdp_bios) for
     /// details.
+    ///
+    /// ### Safety
+    ///
+    /// The caller must ensure that this function is called on BIOS platforms.
     pub unsafe fn search_for_rsdp_bios(handler: H) -> AcpiResult<Self> {
         let rsdp_mapping = unsafe { Rsdp::search_for_on_bios(handler.clone())? };
         // Safety: RSDP has been validated from `Rsdp::search_for_on_bios`
@@ -222,7 +228,9 @@ where
     /// from `from_rsdp` after validation, but can also be used if you've searched for the RSDP manually on a BIOS
     /// system.
     ///
-    /// ### Safety: Caller must ensure that the provided mapping is a fully validated RSDP.
+    /// ### Safety
+    ///
+    /// Caller must ensure that the provided mapping is a fully validated RSDP.
     pub unsafe fn from_validated_rsdp(handler: H, rsdp_mapping: PhysicalMapping<H, Rsdp>) -> AcpiResult<Self> {
         let revision = rsdp_mapping.revision();
         let root_table_mapping = if revision == 0 {
@@ -247,7 +255,9 @@ where
 
     /// Create an `AcpiTables` if you have the physical address of the RSDT/XSDT.
     ///
-    /// ### Safety: Caller must ensure the provided address is valid RSDT/XSDT address.
+    /// ### Safety
+    ///
+    /// Caller must ensure the provided address is valid RSDT/XSDT address.
     pub unsafe fn from_rsdt(handler: H, revision: u8, address: usize) -> AcpiResult<Self> {
         let root_table_mapping = if revision == 0 {
             /*
@@ -408,7 +418,9 @@ impl AmlTable {
     }
 }
 
-/// ### Safety: Caller must ensure the provided address is valid for being read as an `SdtHeader`.
+/// ### Safety
+///
+/// Caller must ensure the provided address is valid for being read as an `SdtHeader`.
 unsafe fn read_table<H: AcpiHandler, T: AcpiTable>(
     handler: H,
     address: usize,

--- a/acpi/src/lib.rs
+++ b/acpi/src/lib.rs
@@ -431,7 +431,7 @@ where
     handler: H,
 }
 
-impl<'t, H> Iterator for SsdtIterator<'t, H>
+impl<H> Iterator for SsdtIterator<'_, H>
 where
     H: AcpiHandler,
 {
@@ -479,7 +479,7 @@ where
     handler: H,
 }
 
-impl<'t, H> Iterator for SdtHeaderIterator<'t, H>
+impl<H> Iterator for SdtHeaderIterator<'_, H>
 where
     H: AcpiHandler,
 {

--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -53,11 +53,8 @@ unsafe impl AcpiTable for Madt {
 impl Madt {
     pub fn get_mpwk_mailbox_addr(&self) -> Result<u64, AcpiError> {
         for entry in self.entries() {
-            match entry {
-                MadtEntry::MultiprocessorWakeup(entry) => {
-                    return Ok(entry.mailbox_address);
-                }
-                _ => {}
+            if let MadtEntry::MultiprocessorWakeup(entry) = entry {
+                return Ok(entry.mailbox_address);
             }
         }
         Err(AcpiError::InvalidMadt(MadtError::UnexpectedEntry))

--- a/acpi/src/managed_slice.rs
+++ b/acpi/src/managed_slice.rs
@@ -16,7 +16,7 @@ where
     allocator: A,
 }
 
-impl<'a, T, A> ManagedSlice<'a, T, A>
+impl<T, A> ManagedSlice<'_, T, A>
 where
     A: Allocator,
 {
@@ -34,13 +34,13 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<'a, T> ManagedSlice<'a, T, alloc::alloc::Global> {
+impl<T> ManagedSlice<'_, T, alloc::alloc::Global> {
     pub fn new(len: usize) -> AcpiResult<Self> {
         Self::new_in(len, alloc::alloc::Global)
     }
 }
 
-impl<'a, T, A> Drop for ManagedSlice<'a, T, A>
+impl<T, A> Drop for ManagedSlice<'_, T, A>
 where
     A: Allocator,
 {
@@ -54,7 +54,7 @@ where
     }
 }
 
-impl<'a, T, A> core::ops::Deref for ManagedSlice<'a, T, A>
+impl<T, A> core::ops::Deref for ManagedSlice<'_, T, A>
 where
     A: Allocator,
 {
@@ -65,7 +65,7 @@ where
     }
 }
 
-impl<'a, T, A> core::ops::DerefMut for ManagedSlice<'a, T, A>
+impl<T, A> core::ops::DerefMut for ManagedSlice<'_, T, A>
 where
     A: Allocator,
 {

--- a/acpi/src/platform/mod.rs
+++ b/acpi/src/platform/mod.rs
@@ -102,7 +102,7 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<'a> PlatformInfo<'a, alloc::alloc::Global> {
+impl PlatformInfo<'_, alloc::alloc::Global> {
     pub fn new<H>(tables: &AcpiTables<H>) -> AcpiResult<Self>
     where
         H: AcpiHandler,
@@ -111,7 +111,7 @@ impl<'a> PlatformInfo<'a, alloc::alloc::Global> {
     }
 }
 
-impl<'a, A> PlatformInfo<'a, A>
+impl<A> PlatformInfo<'_, A>
 where
     A: Allocator + Clone,
 {


### PR DESCRIPTION
* Fix several warnings so that clippy runs cleanly now.
* Add a clippy run on the acpi crate as part of CI.