### PR TITLE
acpi: Remove Clone Copy traits for MADT

### DIFF
--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -34,7 +34,7 @@ pub enum MadtError {
 ///     * The Streamlined Advanced Programmable Interrupt Controller (SAPIC) model (for Itanium systems)
 ///     * The Generic Interrupt Controller (GIC) model (for ARM systems)
 #[repr(C, packed)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub struct Madt {
     pub header: SdtHeader,
     pub local_apic_address: u32,


### PR DESCRIPTION
Copying a Madt struct causes only its fields to be copied, but Madt Entries are lost and trying to read them will result in reading invalid data. 
#218
#234