### PR TITLE
aml: fix clippy warnings and run clippy in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,5 +79,8 @@ jobs:
         profile: minimal
         components: clippy
 
-    - name: Run clippy
+    - name: Run clippy (ACPI)
       run: cargo clippy -p acpi
+
+    - name: Run clippy (AML)
+      run: cargo clippy -p aml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,9 @@ jobs:
     - name: Run clippy (ACPI)
       run: cargo clippy -p acpi
 
+    - name: Run clippy (ACPI tests)
+      run: cargo clippy -p acpi --tests
+
     - name: Run clippy (AML)
       run: cargo clippy -p aml
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,3 +84,6 @@ jobs:
 
     - name: Run clippy (AML)
       run: cargo clippy -p aml
+
+    - name: Run clippy (AML tests)
+      run: cargo clippy -p aml --tests

--- a/aml/src/expression.rs
+++ b/aml/src/expression.rs
@@ -199,7 +199,7 @@ where
                     }
 
                     let mut buffer = vec![0; buffer_size];
-                    (&mut buffer[0..bytes.len()]).copy_from_slice(bytes);
+                    buffer[0..bytes.len()].copy_from_slice(bytes);
                     (Ok(buffer), context)
                 })
             }),
@@ -564,16 +564,16 @@ where
                         context,
                         match source {
                             AmlValue::Buffer(bytes) => {
-                                let foo = bytes.lock();
-                                if index >= foo.len() {
+                                let guard = bytes.lock();
+                                if index >= guard.len() {
                                     Ok(AmlValue::Buffer(Arc::new(spinning_top::Spinlock::new(vec![]))))
-                                } else if (index + length) >= foo.len() {
+                                } else if (index + length) >= guard.len() {
                                     Ok(AmlValue::Buffer(Arc::new(spinning_top::Spinlock::new(
-                                        foo[index..].to_vec(),
+                                        guard[index..].to_vec(),
                                     ))))
                                 } else {
                                     Ok(AmlValue::Buffer(Arc::new(spinning_top::Spinlock::new(
-                                        foo[index..(index + length)].to_vec(),
+                                        guard[index..(index + length)].to_vec(),
                                     ))))
                                 }
                             }

--- a/aml/src/name_object.rs
+++ b/aml/src/name_object.rs
@@ -101,7 +101,7 @@ where
             PREFIX_CHAR => prefix_path.parse(input, context),
             _ => name_path()
                 .map(|path| {
-                    if path.len() == 0 {
+                    if path.is_empty() {
                         return Err(Propagate::Err(AmlError::EmptyNamesAreInvalid));
                     }
 
@@ -175,7 +175,7 @@ pub struct NameSeg(pub(crate) [u8; 4]);
 impl NameSeg {
     pub(crate) fn from_str(string: &str) -> Result<NameSeg, AmlError> {
         // Each NameSeg can only have four chars, and must have at least one
-        if string.len() < 1 || string.len() > 4 {
+        if string.is_empty() || string.len() > 4 {
             return Err(AmlError::InvalidNameSeg);
         }
 
@@ -234,21 +234,18 @@ where
 }
 
 fn is_lead_name_char(byte: u8) -> bool {
-    (byte >= b'A' && byte <= b'Z') || byte == b'_'
-}
-
-fn is_digit_char(byte: u8) -> bool {
-    byte >= b'0' && byte <= b'9'
+    byte.is_ascii_uppercase() || byte == b'_'
 }
 
 fn is_name_char(byte: u8) -> bool {
-    is_lead_name_char(byte) || is_digit_char(byte)
+    is_lead_name_char(byte) || byte.is_ascii_digit()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{parser::Parser, test_utils::*, AmlError};
+    use core::str::FromStr;
 
     #[test]
     fn test_name_seg() {

--- a/aml/src/name_object.rs
+++ b/aml/src/name_object.rs
@@ -252,7 +252,7 @@ mod tests {
         let mut context = crate::test_utils::make_test_context();
 
         check_ok!(
-            name_seg().parse(&[b'A', b'F', b'3', b'Z'], &mut context),
+            name_seg().parse(b"AF3Z", &mut context),
             NameSeg([b'A', b'F', b'3', b'Z']),
             &[]
         );
@@ -292,12 +292,12 @@ mod tests {
         let mut context = crate::test_utils::make_test_context();
 
         check_ok!(
-            name_string().parse(&[b'^', b'A', b'B', b'C', b'D'], &mut context),
+            name_string().parse(b"^ABCD", &mut context),
             AmlName::from_str("^ABCD").unwrap(),
             &[]
         );
         check_ok!(
-            name_string().parse(&[b'^', b'^', b'^', b'A', b'B', b'C', b'D'], &mut context),
+            name_string().parse(b"^^^ABCD", &mut context),
             AmlName::from_str("^^^ABCD").unwrap(),
             &[]
         );

--- a/aml/src/namespace.rs
+++ b/aml/src/namespace.rs
@@ -4,7 +4,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::fmt;
+use core::{fmt, str::FromStr};
 
 /// A handle is used to refer to an AML value without actually borrowing it until you need to
 /// access it (this makes borrowing situation much easier as you only have to consider who's
@@ -70,6 +70,12 @@ pub struct Namespace {
     root: NamespaceLevel,
 }
 
+impl Default for Namespace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Namespace {
     pub fn new() -> Namespace {
         Namespace {
@@ -103,9 +109,7 @@ impl Namespace {
              * If the level has already been added, we don't need to add it again. The parser can try to add it
              * multiple times if the ASL contains multiple blocks that add to the same scope/device.
              */
-            if !level.children.contains_key(&last_seg) {
-                level.children.insert(last_seg, NamespaceLevel::new(typ));
-            }
+            level.children.entry(last_seg).or_insert_with(|| NamespaceLevel::new(typ));
         }
 
         Ok(())
@@ -268,7 +272,7 @@ impl Namespace {
             loop {
                 let name = level_name.resolve(&scope)?;
                 if let Ok((level, last_seg)) = self.get_level_for_path(&name) {
-                    if let Some(_) = level.children.get(&last_seg) {
+                    if level.children.contains_key(&last_seg) {
                         return Ok(name);
                     }
                 }
@@ -342,7 +346,7 @@ impl Namespace {
         where
             F: FnMut(&AmlName, &NamespaceLevel) -> Result<bool, AmlError>,
         {
-            for (name, ref child) in level.children.iter() {
+            for (name, child) in level.children.iter() {
                 let name = AmlName::from_name_seg(*name).resolve(scope)?;
 
                 if f(&name, child)? {
@@ -396,6 +400,39 @@ impl fmt::Debug for Namespace {
     }
 }
 
+impl FromStr for AmlName {
+    type Err = AmlError;
+
+    fn from_str(mut string: &str) -> Result<Self, Self::Err> {
+        if string.is_empty() {
+            return Err(AmlError::EmptyNamesAreInvalid);
+        }
+
+        let mut components = Vec::new();
+
+        // If it starts with a \, make it an absolute name
+        if string.starts_with('\\') {
+            components.push(NameComponent::Root);
+            string = &string[1..];
+        }
+
+        if !string.is_empty() {
+            // Divide the rest of it into segments, and parse those
+            for mut part in string.split('.') {
+                // Handle prefix chars
+                while part.starts_with('^') {
+                    components.push(NameComponent::Prefix);
+                    part = &part[1..];
+                }
+
+                components.push(NameComponent::Segment(NameSeg::from_str(part)?));
+            }
+        }
+
+        Ok(Self(components))
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct AmlName(Vec<NameComponent>);
 
@@ -409,38 +446,8 @@ impl AmlName {
     }
 
     pub fn from_components(components: Vec<NameComponent>) -> AmlName {
-        assert!(components.len() > 0);
+        assert!(!components.is_empty());
         AmlName(components)
-    }
-
-    /// Convert a string representation of an AML name into an `AmlName`.
-    pub fn from_str(mut string: &str) -> Result<AmlName, AmlError> {
-        if string.len() == 0 {
-            return Err(AmlError::EmptyNamesAreInvalid);
-        }
-
-        let mut components = Vec::new();
-
-        // If it starts with a \, make it an absolute name
-        if string.starts_with('\\') {
-            components.push(NameComponent::Root);
-            string = &string[1..];
-        }
-
-        if string.len() > 0 {
-            // Divide the rest of it into segments, and parse those
-            for mut part in string.split('.') {
-                // Handle prefix chars
-                while part.starts_with('^') {
-                    components.push(NameComponent::Prefix);
-                    part = &part[1..];
-                }
-
-                components.push(NameComponent::Segment(NameSeg::from_str(part)?));
-            }
-        }
-
-        Ok(AmlName(components))
     }
 
     pub fn as_string(&self) -> String {
@@ -472,10 +479,7 @@ impl AmlName {
             return false;
         }
 
-        match self.0[0] {
-            NameComponent::Segment(_) => true,
-            _ => false,
-        }
+        matches!(self.0[0], NameComponent::Segment(_))
     }
 
     /// Normalize an AML path, resolving prefix chars. Returns `AmlError::InvalidNormalizedName` if the path
@@ -556,10 +560,10 @@ pub enum NameComponent {
 }
 
 impl NameComponent {
-    pub fn as_segment(self) -> Result<NameSeg, ()> {
+    pub fn as_segment(self) -> Option<NameSeg> {
         match self {
-            NameComponent::Segment(seg) => Ok(seg),
-            NameComponent::Root | NameComponent::Prefix => Err(()),
+            NameComponent::Segment(seg) => Some(seg),
+            NameComponent::Root | NameComponent::Prefix => None,
         }
     }
 }

--- a/aml/src/namespace.rs
+++ b/aml/src/namespace.rs
@@ -600,12 +600,12 @@ mod tests {
 
     #[test]
     fn test_is_normal() {
-        assert_eq!(AmlName::root().is_normal(), true);
-        assert_eq!(AmlName::from_str("\\_SB.PCI0.VGA").unwrap().is_normal(), true);
-        assert_eq!(AmlName::from_str("\\_SB.^PCI0.VGA").unwrap().is_normal(), false);
-        assert_eq!(AmlName::from_str("\\^_SB.^^PCI0.VGA").unwrap().is_normal(), false);
-        assert_eq!(AmlName::from_str("_SB.^^PCI0.VGA").unwrap().is_normal(), false);
-        assert_eq!(AmlName::from_str("_SB.PCI0.VGA").unwrap().is_normal(), true);
+        assert!(AmlName::root().is_normal());
+        assert!(AmlName::from_str("\\_SB.PCI0.VGA").unwrap().is_normal());
+        assert!(!AmlName::from_str("\\_SB.^PCI0.VGA").unwrap().is_normal());
+        assert!(!AmlName::from_str("\\^_SB.^^PCI0.VGA").unwrap().is_normal());
+        assert!(!AmlName::from_str("_SB.^^PCI0.VGA").unwrap().is_normal());
+        assert!(AmlName::from_str("_SB.PCI0.VGA").unwrap().is_normal());
     }
 
     #[test]
@@ -638,22 +638,22 @@ mod tests {
 
     #[test]
     fn test_is_absolute() {
-        assert_eq!(AmlName::root().is_absolute(), true);
-        assert_eq!(AmlName::from_str("\\_SB.PCI0.VGA").unwrap().is_absolute(), true);
-        assert_eq!(AmlName::from_str("\\_SB.^PCI0.VGA").unwrap().is_absolute(), true);
-        assert_eq!(AmlName::from_str("\\^_SB.^^PCI0.VGA").unwrap().is_absolute(), true);
-        assert_eq!(AmlName::from_str("_SB.^^PCI0.VGA").unwrap().is_absolute(), false);
-        assert_eq!(AmlName::from_str("_SB.PCI0.VGA").unwrap().is_absolute(), false);
+        assert!(AmlName::root().is_absolute());
+        assert!(AmlName::from_str("\\_SB.PCI0.VGA").unwrap().is_absolute());
+        assert!(AmlName::from_str("\\_SB.^PCI0.VGA").unwrap().is_absolute());
+        assert!(AmlName::from_str("\\^_SB.^^PCI0.VGA").unwrap().is_absolute());
+        assert!(!AmlName::from_str("_SB.^^PCI0.VGA").unwrap().is_absolute());
+        assert!(!AmlName::from_str("_SB.PCI0.VGA").unwrap().is_absolute());
     }
 
     #[test]
     fn test_search_rules_apply() {
-        assert_eq!(AmlName::root().search_rules_apply(), false);
-        assert_eq!(AmlName::from_str("\\_SB").unwrap().search_rules_apply(), false);
-        assert_eq!(AmlName::from_str("^VGA").unwrap().search_rules_apply(), false);
-        assert_eq!(AmlName::from_str("_SB.PCI0.VGA").unwrap().search_rules_apply(), false);
-        assert_eq!(AmlName::from_str("VGA").unwrap().search_rules_apply(), true);
-        assert_eq!(AmlName::from_str("_SB").unwrap().search_rules_apply(), true);
+        assert!(!AmlName::root().search_rules_apply());
+        assert!(!AmlName::from_str("\\_SB").unwrap().search_rules_apply());
+        assert!(!AmlName::from_str("^VGA").unwrap().search_rules_apply());
+        assert!(!AmlName::from_str("_SB.PCI0.VGA").unwrap().search_rules_apply());
+        assert!(AmlName::from_str("VGA").unwrap().search_rules_apply());
+        assert!(AmlName::from_str("_SB").unwrap().search_rules_apply());
     }
 
     #[test]

--- a/aml/src/opregion.rs
+++ b/aml/src/opregion.rs
@@ -6,6 +6,7 @@ use crate::{
     AmlValue,
 };
 use bit_field::BitField;
+use core::str::FromStr;
 
 #[derive(Clone, Debug)]
 pub struct OpRegion {
@@ -187,10 +188,22 @@ impl OpRegion {
             RegionSpace::SystemMemory => {
                 let address = (self.base + offset).try_into().map_err(|_| AmlError::FieldInvalidAddress)?;
                 match length {
-                    8 => Ok(context.handler.write_u8(address, value as u8)),
-                    16 => Ok(context.handler.write_u16(address, value as u16)),
-                    32 => Ok(context.handler.write_u32(address, value as u32)),
-                    64 => Ok(context.handler.write_u64(address, value)),
+                    8 => {
+                        context.handler.write_u8(address, value as u8);
+                        Ok(())
+                    }
+                    16 => {
+                        context.handler.write_u16(address, value as u16);
+                        Ok(())
+                    }
+                    32 => {
+                        context.handler.write_u32(address, value as u32);
+                        Ok(())
+                    }
+                    64 => {
+                        context.handler.write_u64(address, value);
+                        Ok(())
+                    }
                     _ => Err(AmlError::FieldInvalidAccessSize),
                 }
             }
@@ -198,9 +211,18 @@ impl OpRegion {
             RegionSpace::SystemIo => {
                 let port = (self.base + offset).try_into().map_err(|_| AmlError::FieldInvalidAddress)?;
                 match length {
-                    8 => Ok(context.handler.write_io_u8(port, value as u8)),
-                    16 => Ok(context.handler.write_io_u16(port, value as u16)),
-                    32 => Ok(context.handler.write_io_u32(port, value as u32)),
+                    8 => {
+                        context.handler.write_io_u8(port, value as u8);
+                        Ok(())
+                    }
+                    16 => {
+                        context.handler.write_io_u16(port, value as u16);
+                        Ok(())
+                    }
+                    32 => {
+                        context.handler.write_io_u32(port, value as u32);
+                        Ok(())
+                    }
                     _ => Err(AmlError::FieldInvalidAccessSize),
                 }
             }
@@ -241,9 +263,18 @@ impl OpRegion {
                 let offset = (self.base + offset).try_into().map_err(|_| AmlError::FieldInvalidAddress)?;
 
                 match length {
-                    8 => Ok(context.handler.write_pci_u8(seg, bbn, device, function, offset, value as u8)),
-                    16 => Ok(context.handler.write_pci_u16(seg, bbn, device, function, offset, value as u16)),
-                    32 => Ok(context.handler.write_pci_u32(seg, bbn, device, function, offset, value as u32)),
+                    8 => {
+                        context.handler.write_pci_u8(seg, bbn, device, function, offset, value as u8);
+                        Ok(())
+                    }
+                    16 => {
+                        context.handler.write_pci_u16(seg, bbn, device, function, offset, value as u16);
+                        Ok(())
+                    }
+                    32 => {
+                        context.handler.write_pci_u32(seg, bbn, device, function, offset, value as u32);
+                        Ok(())
+                    }
                     _ => Err(AmlError::FieldInvalidAccessSize),
                 }
             }

--- a/aml/src/parser.rs
+++ b/aml/src/parser.rs
@@ -62,6 +62,7 @@ where
     /// parsing with `other`, returning the result of that parser in all cases. Other errors from the first
     /// parser are propagated without attempting the second parser. To chain more than two parsers using
     /// `or`, see the `choice!` macro.
+    #[allow(unused)]
     fn or<OtherParser>(self, other: OtherParser) -> Or<'a, 'c, Self, OtherParser, R>
     where
         OtherParser: Parser<'a, 'c, R>,

--- a/aml/src/pci_routing.rs
+++ b/aml/src/pci_routing.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 use bit_field::BitField;
+use core::str::FromStr;
 
 pub use crate::resource::IrqDescriptor;
 
@@ -60,7 +61,7 @@ impl PciRoutingTable {
     pub fn from_prt_path(prt_path: &AmlName, context: &mut AmlContext) -> Result<PciRoutingTable, AmlError> {
         let mut entries = Vec::new();
 
-        let prt = context.invoke_method(&prt_path, Args::default())?;
+        let prt = context.invoke_method(prt_path, Args::default())?;
         if let AmlValue::Package(ref inner_values) = prt {
             for value in inner_values {
                 if let AmlValue::Package(ref pin_package) = value {
@@ -118,7 +119,7 @@ impl PciRoutingTable {
                         }
                         AmlValue::String(ref name) => {
                             let link_object_name =
-                                context.namespace.search_for_level(&AmlName::from_str(name)?, &prt_path)?;
+                                context.namespace.search_for_level(&AmlName::from_str(name)?, prt_path)?;
                             entries.push(PciRoute {
                                 device,
                                 function,

--- a/aml/src/pkg_length.rs
+++ b/aml/src/pkg_length.rs
@@ -189,7 +189,7 @@ mod tests {
 
         check_ok!(
             pkg_length()
-                .feed(|length| crate::parser::take_to_end_of_pkglength(length))
+                .feed(crate::parser::take_to_end_of_pkglength)
                 .parse(&[0x05, 0x01, 0x02, 0x03, 0x04, 0xff, 0xff, 0xff], &mut context),
             &[0x01, 0x02, 0x03, 0x04],
             &[0xff, 0xff, 0xff]

--- a/aml/src/resource.rs
+++ b/aml/src/resource.rs
@@ -25,7 +25,7 @@ pub fn resource_descriptor_list(descriptor: &AmlValue) -> Result<Vec<Resource>, 
         let buffer_data = bytes.lock();
         let mut bytes = buffer_data.as_slice();
 
-        while bytes.len() > 0 {
+        while !bytes.is_empty() {
             let (descriptor, remaining_bytes) = resource_descriptor(bytes)?;
 
             if let Some(descriptor) = descriptor {

--- a/aml/src/statement.rs
+++ b/aml/src/statement.rs
@@ -153,7 +153,7 @@ where
                         .then(comment_scope(
                             DebugVerbosity::AllScopes,
                             "DefElse",
-                            pkg_length().feed(|length| take_to_end_of_pkglength(length)),
+                            pkg_length().feed(take_to_end_of_pkglength),
                         ))
                         .map(|((), else_branch): ((), &[u8])| Ok(else_branch)),
                     // TODO: can this be `id().map(&[])`?

--- a/aml/src/term_object.rs
+++ b/aml/src/term_object.rs
@@ -1056,7 +1056,7 @@ mod test {
         );
         check_ok_value!(
             computational_data().parse(&[0xff, 0x98, 0xc3], &mut context),
-            AmlValue::Integer(u64::max_value()),
+            AmlValue::Integer(u64::MAX),
             &[0x98, 0xc3]
         );
         check_ok_value!(

--- a/aml/src/test_utils.rs
+++ b/aml/src/test_utils.rs
@@ -125,10 +125,7 @@ pub(crate) fn crudely_cmp_values(a: &AmlValue, b: &AmlValue) -> bool {
     use crate::value::MethodCode;
 
     match a {
-        AmlValue::Uninitialized => match b {
-            AmlValue::Uninitialized => true,
-            _ => false,
-        },
+        AmlValue::Uninitialized => matches!(b, AmlValue::Uninitialized),
         AmlValue::Boolean(a) => match b {
             AmlValue::Boolean(b) => a == b,
             _ => false,
@@ -151,10 +148,7 @@ pub(crate) fn crudely_cmp_values(a: &AmlValue, b: &AmlValue) -> bool {
             }
             _ => false,
         },
-        AmlValue::Device => match b {
-            AmlValue::Device => true,
-            _ => false,
-        },
+        AmlValue::Device => matches!(b, AmlValue::Device),
         AmlValue::Method { flags, code } => match b {
             AmlValue::Method { flags: b_flags, code: b_code } => {
                 if flags != b_flags {
@@ -195,7 +189,7 @@ pub(crate) fn crudely_cmp_values(a: &AmlValue, b: &AmlValue) -> bool {
         AmlValue::Package(a) => match b {
             AmlValue::Package(b) => {
                 for (a, b) in a.iter().zip(b) {
-                    if crudely_cmp_values(a, b) == false {
+                    if !crudely_cmp_values(a, b) {
                         return false;
                     }
                 }
@@ -210,9 +204,6 @@ pub(crate) fn crudely_cmp_values(a: &AmlValue, b: &AmlValue) -> bool {
             }
             _ => false,
         },
-        AmlValue::ThermalZone => match b {
-            AmlValue::ThermalZone => true,
-            _ => false,
-        },
+        AmlValue::ThermalZone => matches!(b, AmlValue::ThermalZone),
     }
 }


### PR DESCRIPTION
* Fix several warnings so that clippy runs cleanly on the AML crate and its tests.
* Add clippy runs on the AML crate and its tests as part of CI.
* Add a missing clippy run on the ACPI crate tests.