### PR TITLE
acpi: Remove Clone Copy traits for MADT

### DIFF
--- a/acpi/src/madt.rs
+++ b/acpi/src/madt.rs
@@ -34,7 +34,7 @@ pub enum MadtError {
 ///     * The Streamlined Advanced Programmable Interrupt Controller (SAPIC) model (for Itanium systems)
 ///     * The Generic Interrupt Controller (GIC) model (for ARM systems)
 #[repr(C, packed)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub struct Madt {
     pub header: SdtHeader,
     pub local_apic_address: u32,


### PR DESCRIPTION
Copying and cloning a MADT does not copy Entries, so the cloned MADT is invalid.
But or maybe it's worth doing this: #223