### PR TITLE
Fix all clippy warnings and run CI for all workspace packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,8 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-Dwarnings"
     steps:
     - uses: actions/checkout@v2
       with:
@@ -79,14 +81,8 @@ jobs:
         profile: minimal
         components: clippy
 
-    - name: Run clippy (ACPI)
-      run: cargo clippy -p acpi
+    - name: Run clippy
+      run: cargo clippy --all
 
-    - name: Run clippy (ACPI tests)
-      run: cargo clippy -p acpi --tests
-
-    - name: Run clippy (AML)
-      run: cargo clippy -p aml
-
-    - name: Run clippy (AML tests)
-      run: cargo clippy -p aml --tests
+    - name: Run clippy (tests)
+      run: cargo clippy --all --tests

--- a/aml/src/value.rs
+++ b/aml/src/value.rs
@@ -494,7 +494,7 @@ impl AmlValue {
                      */
                     let bits_to_copy = cmp::min(length, 64);
                     bitslice[offset..(offset + bits_to_copy)]
-                        .copy_from_bitslice(&value.to_le_bytes().view_bits()[..(bits_to_copy as usize)]);
+                        .copy_from_bitslice(&value.to_le_bytes().view_bits()[..(bits_to_copy)]);
                     // Zero extend to the end of the buffer field
                     bitslice[(offset + bits_to_copy)..(offset + length)].fill(false);
                     Ok(())
@@ -514,7 +514,7 @@ impl AmlValue {
                     let value_data = value.lock();
                     let bits_to_copy = cmp::min(length, value_data.len() * 8);
                     bitslice[offset..(offset + bits_to_copy)]
-                        .copy_from_bitslice(&value_data.view_bits()[..(bits_to_copy as usize)]);
+                        .copy_from_bitslice(&value_data.view_bits()[..(bits_to_copy)]);
                     // Zero extend to the end of the buffer field
                     bitslice[(offset + bits_to_copy)..(offset + length)].fill(false);
                     Ok(())
@@ -560,7 +560,7 @@ impl Args {
         }
 
         let mut args: Vec<Option<AmlValue>> = list.into_iter().map(Option::Some).collect();
-        args.extend(core::iter::repeat(None).take(7 - args.len()));
+        args.extend(core::iter::repeat_n(None, 7 - args.len()));
         Ok(Args(args.try_into().unwrap()))
     }
 

--- a/rsdp/src/handler.rs
+++ b/rsdp/src/handler.rs
@@ -33,6 +33,10 @@ where
     ///   than `region_length`, due to requirements of the paging system or other reasoning.
     /// - `handler` should be the same `AcpiHandler` that created the mapping. When the `PhysicalMapping` is
     ///   dropped, it will be used to unmap the structure.
+    ///
+    /// # Safety
+    ///
+    /// The caller must make sure that the parameters correctly represent an existing mapping.
     pub unsafe fn new(
         physical_start: usize,
         virtual_start: NonNull<T>,


### PR DESCRIPTION
Fix remaining clippy warnigns and run CI for all workspace packages.

While we are at it, deny clippy warnings, which were previously slipping through.