### PR TITLE
Add Support for Multiple IRQs in IrqDescriptor

### DIFF
--- a/aml/src/pci_routing.rs
+++ b/aml/src/pci_routing.rs
@@ -1,6 +1,6 @@
 use crate::{
     namespace::AmlName,
-    resource::{self, InterruptPolarity, InterruptTrigger, Resource},
+    resource::{self, InterruptPolarity, InterruptTrigger, Irq, Resource},
     value::Args,
     AmlContext,
     AmlError,
@@ -169,7 +169,7 @@ impl PciRoutingTable {
                 polarity: InterruptPolarity::ActiveLow,
                 is_shared: true,
                 is_wake_capable: false,
-                irq: gsi,
+                irq: Irq::Single(gsi),
             }),
             PciRouteType::LinkObject(ref name) => {
                 let path = AmlName::from_str("_CRS").unwrap().resolve(name)?;


### PR DESCRIPTION
Simply makes IRQs an enum which can contain a single interrupt or multiple. This helps with keeping most of previous compatibility with minimal changes. This would still be a breaking API change though.

Related to and closes #250 