### PR TITLE
Add a toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
I'm not sure how you'll like this one @IsaacWoods, since not everyone likes the idea of toolchain files... But since the library only compiles on nightly, would you object to adding one?

It has a couple of benefits from my point of view...
1. RustRover (and probably other IDEs) are better at spotting errors, they don't get hung up no the use of `#![feature]`
2. Much less typing of `+nightly` on each command...
