### PR TITLE
Typo - update PCI config location

### DIFF
--- a/src/aml/mod.rs
+++ b/src/aml/mod.rs
@@ -2630,7 +2630,7 @@ where
             Some(value) => value.as_integer()?,
             None => 0,
         };
-        let bus = match self.evaluate_if_present(AmlName::from_str("_BBR").unwrap().resolve(path)?, vec![])? {
+        let bus = match self.evaluate_if_present(AmlName::from_str("_BBN").unwrap().resolve(path)?, vec![])? {
             Some(value) => value.as_integer()?,
             None => 0,
         };


### PR DESCRIPTION
I think there's a straightforward typo here - the ACPI spec refers to `_BBN` for bus location, not `_BBR`, and `_BBR` doesn't feature in any Google hits (so I don't think it was in a previous iteration of the spec)