### PR TITLE
Derive Clone, Debug on useful objects

### DIFF
--- a/src/platform/numa.rs
+++ b/src/platform/numa.rs
@@ -11,6 +11,7 @@ use core::alloc::Allocator;
 
 /// Information about the setup of NUMA (Non-Uniform Memory Architecture) resources within the
 /// sytem.
+#[derive(Clone, Debug)]
 pub struct NumaInfo<A: Allocator = Global> {
     pub processor_affinity: Vec<ProcessorAffinity, A>,
     pub memory_affinity: Vec<MemoryAffinity, A>,

--- a/src/platform/pci.rs
+++ b/src/platform/pci.rs
@@ -17,6 +17,7 @@ use alloc::{
 /// function of a PCIe device, [`PciConfigRegions::physical_address`] will give you the physical
 /// address of the start of that device function's configuration space (each function has 4096
 /// bytes of configuration space in PCIe).
+#[derive(Clone, Debug)]
 pub struct PciConfigRegions<A: Allocator = Global> {
     pub regions: Vec<McfgEntry, A>,
 }


### PR DESCRIPTION
In my project I found it would be useful to have an explicit Clone for `PciConfigRegions`. Looking through the platform structs, I also saw `NumaInfo` looked like it would benefit from Clone.

Plus since neither struct is self-referential, I added a Debug derive because I find it useful surprisingly often!

Any objections?