### PR TITLE
Get referenced-package size - unwrap reference in `do_size_of`

### DIFF
--- a/src/aml/mod.rs
+++ b/src/aml/mod.rs
@@ -2293,7 +2293,7 @@ where
 
     fn do_size_of(&self, context: &mut MethodContext, op: OpInFlight) -> Result<(), AmlError> {
         extract_args!(op => [Argument::Object(object)]);
-        let object = object.clone().unwrap_transparent_reference();
+        let object = object.clone().unwrap_reference();
 
         let result = match *object {
             Object::Buffer(ref buffer) => buffer.len(),

--- a/tests/package_sizeof.asl
+++ b/tests/package_sizeof.asl
@@ -1,0 +1,22 @@
+DefinitionBlock("", "DSDT", 1, "RSACPI", "PACKGE", 1) {
+    // Checks fix for issue 282 - SizeOf on a reference to a package doesn't work.
+    Name(FOO, Package (3) {
+        Package (0x01) {
+                0x1,
+            },
+
+        Package (0x01) {
+            0x02,
+        },
+
+        Package (0x01) {
+            0x03,
+        }
+    })
+
+    Method (MAIN, 0, NotSerialized) {
+        Local0 = Sizeof (FOO)
+        Local1 = Sizeof (FOO[0]) // This was what failed in issue 282.
+        Return ((Local0 != 3) || (Local1 != 1))
+    }
+}


### PR DESCRIPTION
Pretty much what it says in the title. Closes #282 

I didn't do anything fancy like I thought I might do, just a simple fix here.