### PR TITLE
(minor) Trace the table ID better

### DIFF
--- a/tools/aml_test_tools/src/lib.rs
+++ b/tools/aml_test_tools/src/lib.rs
@@ -378,7 +378,13 @@ where
         let others = tables.iter().filter(|t| t.header().signature != Signature::DSDT);
 
         for t in others {
-            trace!("Loading table: {:?}", t.header().signature);
+            let h = t.header();
+            trace!(
+                "Loading table: {:?}/{:?}/{:?}",
+                h.signature,
+                str::from_utf8(&h.oem_id).unwrap_or("Unknown"),
+                str::from_utf8(&h.oem_table_id).unwrap_or("Unknown")
+            );
             interpreter.load_table(t.content())?;
         }
 


### PR DESCRIPTION
This is helpful when debugging ACPI dumps with multiple SSDTs...