### PR TITLE
Fix regression in implicit casting from integer -> string

### DIFF
--- a/src/aml/object.rs
+++ b/src/aml/object.rs
@@ -316,7 +316,7 @@ impl Object {
                 *value = u64::from_le_bytes(bytes);
             }
             Object::String(value) => {
-                *value = String::from_utf8_lossy(&new_bytes).to_string();
+                *value = String::from_utf8_lossy(&new_bytes).split('\0').next().unwrap().to_string();
             }
             Object::Buffer(value) => {
                 *value = new_bytes.to_vec();


### PR DESCRIPTION
Looks like the recent work with implicit conversions / object comparison introduced a regression in the uACPI `implicit_case_semantics` test.

Modelling AML strings in Rust is tricky; conversion from byte slices with `String::from_utf8_lossy` keeps trailing null bytes - this is likely fine in C because of how string comparisons would work, but trips up comparison in Rust's `String` (and `CString` cannot have multiple trailing null bytes).

This fixes that by stripping trailing nul bytes entirely when converting integers/buffers to strings. It may be that the correct place to fix this holistically is rather in the object comparsion, but this seems like a reasonable step given the current failing case.