### PR TITLE
fix: Added one match to ignore non-exist method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ pretty_env_logger = "0.5.0"
 [features]
 default = ["alloc", "aml"]
 alloc = []
+aml_nonstrict = ["aml"]
 aml = ["alloc"]

--- a/src/aml/mod.rs
+++ b/src/aml/mod.rs
@@ -1568,6 +1568,18 @@ where
                                         Object::Reference { kind: ReferenceKind::Named, inner: object }.wrap(),
                                     ));
                                 }
+                                Err(AmlError::ObjectDoesNotExist(name)) => {
+                                    // For some real machine, it might use the same template, so it
+                                    // cant be fully deleted.
+                                    // So here, we shall give a warn and continue...
+                                    warn!("An AML path named {} does not found, skipping...", name);
+
+                                    let reference = Object::Reference {
+                                        kind: ReferenceKind::Unresolved,
+                                        inner: Object::String(name.to_string()).wrap(),
+                                    };
+                                    context.contribute_arg(Argument::Object(reference.wrap()));
+                                }
                                 Err(err) => Err(err)?,
                             }
                         }

--- a/src/aml/mod.rs
+++ b/src/aml/mod.rs
@@ -1568,11 +1568,13 @@ where
                                         Object::Reference { kind: ReferenceKind::Named, inner: object }.wrap(),
                                     ));
                                 }
+
+                                #[cfg(feature = "aml_nonstrict")]
                                 Err(AmlError::ObjectDoesNotExist(name)) => {
-                                    // For some real machine, it might use the same template, so it
-                                    // cant be fully deleted.
-                                    // So here, we shall give a warn and continue...
-                                    warn!("An AML path named {} does not found, skipping...", name);
+                                    // XXX: For some machines, it might forget to remove wrong things from the namespace, and then later on refer to them again. 
+                                    // In this case, we should just ignore the missing object and continue, rather than erroring out. 
+                                    // See https://github.com/rust-osdev/acpi/issues/308 for more details.
+                                    warn!("An AML path which is named \"{}\" does not found, skipping...", name);
 
                                     let reference = Object::Reference {
                                         kind: ReferenceKind::Unresolved,
@@ -1580,6 +1582,7 @@ where
                                     };
                                     context.contribute_arg(Argument::Object(reference.wrap()));
                                 }
+
                                 Err(err) => Err(err)?,
                             }
                         }

--- a/tests/operation_region.rs
+++ b/tests/operation_region.rs
@@ -1,4 +1,12 @@
-use aml_test_tools::handlers::std_test_handler::{Command, construct_std_handler, create_mutex, read_u8, write_pci_u8, write_u8, read_pci_u8};
+use aml_test_tools::handlers::std_test_handler::{
+    Command,
+    construct_std_handler,
+    create_mutex,
+    read_pci_u8,
+    read_u8,
+    write_pci_u8,
+    write_u8,
+};
 use pci_types::PciAddress;
 
 mod test_infra;

--- a/tests/test_infra/mod.rs
+++ b/tests/test_infra/mod.rs
@@ -1,5 +1,12 @@
 use acpi::Handler;
-use aml_test_tools::{RunTestResult, TestResult, handlers::logging_handler::LoggingHandler, new_interpreter, run_test_for_string, run_test_for_opcodes};
+use aml_test_tools::{
+    RunTestResult,
+    TestResult,
+    handlers::logging_handler::LoggingHandler,
+    new_interpreter,
+    run_test_for_opcodes,
+    run_test_for_string,
+};
 
 // The following two functions are very similar in structure, but whilst there are only two of them
 // it's not worth adding complexity to make them DRY.

--- a/tests/uacpi_examples.rs
+++ b/tests/uacpi_examples.rs
@@ -9,7 +9,7 @@
 
 mod test_infra;
 
-use aml_test_tools::{handlers::null_handler::NullHandler};
+use aml_test_tools::handlers::null_handler::NullHandler;
 
 #[test]
 fn expressions_with_package() {

--- a/tools/aml_test_tools/src/handlers/check_cmd_handler.rs
+++ b/tools/aml_test_tools/src/handlers/check_cmd_handler.rs
@@ -271,8 +271,8 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::handlers::null_handler::NullHandler;
     use super::*;
+    use crate::handlers::null_handler::NullHandler;
 
     #[test]
     fn handler_basic_functions() {

--- a/tools/aml_test_tools/src/handlers/std_test_handler.rs
+++ b/tools/aml_test_tools/src/handlers/std_test_handler.rs
@@ -1,12 +1,12 @@
 //! Rather than defining a [`Handler`], this module defines useful functions to streamline the most-
 //! used case of a [`CheckCommandHandler`] wrapping a [`ListedResponseHandler`].
 
-use pci_types::PciAddress;
 use crate::handlers::{
     check_cmd_handler::{AcpiCommands as Check, CheckCommandHandler},
     listed_response_handler::{AcpiCommands as Response, ListedResponseHandler},
 };
 use acpi::{Handle, Handler};
+use pci_types::PciAddress;
 
 /// Simplifies the construction of a standard test [`Handler`].
 ///


### PR DESCRIPTION
### Problem
While initializing the AML interpreter, the interpreter returns an `AmlError::ObjectDoesNotExist` within the path `\_SB.PCI0.I2C1.TPL1.ICID`. Seems this is touchpad's entry, but this is PC, not laptop, and i didn't install any touchpad hardware!

See also [here](https://github.com/rust-osdev/acpi/issues/308)

### What I did
So this modification did:
 - Added one branch to handle `AmlError::ObjectDoesNotExist` in `ResolveBehaviour::SimpleName | ResolveBehaviour::SuperName | ResolveBehaviour::Target` ;
 - Added a feature to decide to enable them or not (`aml_nonstrict`, default to false)

During modification, i didn't destroy any of existed code, so it can continuely use as before.

### Test result
Once I added the code, rebuild and run on my machine, it just returned some warning instead of causing panics. (Will attach pictures later)