### PR TITLE
fix(rsdp): fix rsdp revision and rsdp checksum to fit linux kernel impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,15 +112,12 @@ where
         }
 
         let rsdp_revision = rsdp_mapping.revision();
-        let rsdt_address = if rsdp_revision == 0 {
-            // We're running on ACPI Version 1.0. We should use the 32-bit RSDT address.
-            rsdp_mapping.rsdt_address() as usize
-        } else {
-            /*
-             * We're running on ACPI Version 2.0+. We should use the 64-bit XSDT address, truncated
-             * to 32 bits on x86.
-             */
+        // Use XSDT only when revision > 1, following Linux (tbutils.c).
+        // revision == 0 and revision == 1 both use the 32-bit RSDT address.
+        let rsdt_address = if rsdp_revision > 1 {
             rsdp_mapping.xsdt_address() as usize
+        } else {
+            rsdp_mapping.rsdt_address() as usize
         };
 
         unsafe { Self::from_rsdt(handler, rsdp_revision, rsdt_address) }

--- a/src/rsdp.rs
+++ b/src/rsdp.rs
@@ -3,6 +3,8 @@ use core::{mem, ops::Range, slice, str};
 
 /// The size in bytes of the ACPI 1.0 RSDP.
 const RSDP_V1_LENGTH: usize = 20;
+/// The size in bytes covered by the ACPI 2.0+ extended checksum (mirrors Linux ACPI_RSDP_XCHECKSUM_LENGTH).
+const RSDP_XCHECKSUM_LENGTH: usize = 36;
 /// The total size in bytes of the RSDP fields introduced in ACPI 2.0.
 const RSDP_V2_EXT_LENGTH: usize = mem::size_of::<Rsdp>() - RSDP_V1_LENGTH;
 
@@ -114,10 +116,17 @@ impl Rsdp {
         /*
          * `self.length` doesn't exist on ACPI version 1.0, so we mustn't rely on it. Instead,
          * check for version 1.0 and use a hard-coded length instead.
+         *
+         * For Version 2.0+, use the fixed constant size_of::<Rsdp>() (= 36) rather than
+         * `self.length`, following Linux's ACPI_RSDP_XCHECKSUM_LENGTH. Trusting the
+         * firmware-provided `length` is unsafe: if it exceeds 36, `slice::from_raw_parts`
+         * would read past the mapped region, causing undefined behaviour.
          */
         let length = if self.revision > 0 {
-            // For Version 2.0+, include the number of bytes specified by `length`
-            self.length as usize
+            if self.length as usize > RSDP_XCHECKSUM_LENGTH {
+                return Err(AcpiError::RsdpInvalidChecksum);
+            }
+            RSDP_XCHECKSUM_LENGTH
         } else {
             RSDP_V1_LENGTH
         };

--- a/src/rsdp.rs
+++ b/src/rsdp.rs
@@ -117,15 +117,9 @@ impl Rsdp {
          * `self.length` doesn't exist on ACPI version 1.0, so we mustn't rely on it. Instead,
          * check for version 1.0 and use a hard-coded length instead.
          *
-         * For Version 2.0+, use the fixed constant size_of::<Rsdp>() (= 36) rather than
-         * `self.length`, following Linux's ACPI_RSDP_XCHECKSUM_LENGTH. Trusting the
-         * firmware-provided `length` is unsafe: if it exceeds 36, `slice::from_raw_parts`
-         * would read past the mapped region, causing undefined behaviour.
+         * For Version 2.0+, use the Linux's ACPI_RSDP_XCHECKSUM_LENGTH.
          */
-        let length = if self.revision > 0 {
-            if self.length as usize > RSDP_XCHECKSUM_LENGTH {
-                return Err(AcpiError::RsdpInvalidChecksum);
-            }
+        let length = if self.revision > 1 {
             RSDP_XCHECKSUM_LENGTH
         } else {
             RSDP_V1_LENGTH


### PR DESCRIPTION

1. In Linux kernel source in `drivers/acpi/acpica/tbutils.c` line 242-259 shows that: when `revision` > 1, use XSDT. and `revision` = 0 or 1 use RSDT.
```c
	/* Use XSDT if present and not overridden. Otherwise, use RSDT */

	if ((rsdp->revision > 1) &&
	    rsdp->xsdt_physical_address && !acpi_gbl_do_not_use_xsdt) {
		/*
		 * RSDP contains an XSDT (64-bit physical addresses). We must use
		 * the XSDT if the revision is > 1 and the XSDT pointer is present,
		 * as per the ACPI specification.
		 */
		address = (acpi_physical_address)rsdp->xsdt_physical_address;
		table_entry_size = ACPI_XSDT_ENTRY_SIZE;
	} else {
		/* Root table is an RSDT (32-bit physical addresses) */

		address = (acpi_physical_address)rsdp->rsdt_physical_address;
		table_entry_size = ACPI_RSDT_ENTRY_SIZE;
	}
```
in `acpi-rs` in `acpi/src/lib.rs` line 233-248 shows that: only `revision ==0 ` use RSDT, other use XSDT.
```rust
 let revision = rsdp_mapping.revision();
        let root_table_mapping = if revision == 0 {
            /*
             * We're running on ACPI Version 1.0. We should use the 32-bit RSDT address.
             */

            read_root_table!(RSDT, rsdt_address)
        } else {
            /*
             * We're running on ACPI Version 2.0+. We should use the 64-bit XSDT address, truncated
             * to 32 bits on x86.
             */

            read_root_table!(XSDT, xsdt_address)
        };

        Ok(Self { mapping: root_table_mapping, revision, handler })
    }
```

so , when revision = 1, linux will regard it as RSDT, but acpi-rs see it as a XSDT.
2. the checksum len in acpi 2.0 condition.
in linux source `drivers/acpi/acpica/tbxfroot.c` line 59-89. 

the acpi2.0 checksum len is a constant `ACPI_RSDP_XCHECKSUM_LENGTH`  valued 36 and its defined in `include/acpi/acconfig.h` in line 173:
```c
/* RSDP checksums */
#define ACPI_RSDP_CHECKSUM_LENGTH       20
#define ACPI_RSDP_XCHECKSUM_LENGTH      36
```

```c
acpi_status acpi_tb_validate_rsdp(struct acpi_table_rsdp *rsdp)
{

	/*
	 * The signature and checksum must both be correct
	 *
	 * Note: Sometimes there exists more than one RSDP in memory; the valid
	 * RSDP has a valid checksum, all others have an invalid checksum.
	 */
	if (!ACPI_VALIDATE_RSDP_SIG(rsdp->signature)) {

		/* Nope, BAD Signature */

		return (AE_BAD_SIGNATURE);
	}

	/* Check the standard checksum */

	if (acpi_ut_checksum((u8 *)rsdp, ACPI_RSDP_CHECKSUM_LENGTH) != 0) {
		return (AE_BAD_CHECKSUM);
	}

	/* Check extended checksum if table version >= 2 */

	if ((rsdp->revision >= 2) &&
	    (acpi_ut_checksum((u8 *)rsdp, ACPI_RSDP_XCHECKSUM_LENGTH) != 0)) {
		return (AE_BAD_CHECKSUM);
	}

	return (AE_OK);
}
```

but in acpi-rs in `acpi/src/rsdp.rs` line 119-127 it use `self.length`

```rust
   let length = if self.revision > 0 {
            // For Version 2.0+, include the number of bytes specified by `length`
            self.length as usize
        } else {
            RSDP_V1_LENGTH
        };

        let bytes = unsafe { slice::from_raw_parts(self as *const Rsdp as *const u8, length) };
        let sum = bytes.iter().fold(0u8, |sum, &byte| sum.wrapping_add(byte));
```
so when the length of `RSDP` in memory is not 36 and use ACPI2.0, linux will also see it as 36,but acpi-rs not. 

and if firmware write the `lenght` > 36, acpi-rs will read over the range and go into UB.
