### PR TITLE
fix: Fix exported_private_dependencies

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [alias]
 run_tests = "run --manifest-path tools/aml-tester/Cargo.toml --"
+
+[unstable]
+public-dependency = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,12 @@ edition = "2024"
 [dependencies]
 bit_field = "0.10.2"
 bitflags = "2.5.0"
+lock_api = { version = "0.4.14", optional = true, public = true }
 log = "0.4.20"
-spinning_top = { version = "0.3.0", optional = true }
+spinning_top = { version = "0.3.0", optional = true, public = true }
 pci_types = { version = "0.10.0", public = true }
 byteorder = { version = "1.5.0", optional = true, default-features = false }
-smallvec = { version = "1.15.2", optional = true, default-features = false }
+smallvec = { version = "1.15.2", optional = true, default-features = false, public = true }
 
 [dev-dependencies]
 aml-test-tools = { path = "tools/aml-test-tools" }
@@ -35,6 +36,7 @@ default = ["alloc", "aml"]
 alloc = []
 aml = [
     "alloc",
+    "dep:lock_api",
     "dep:spinning_top",
     "dep:byteorder",
     "dep:smallvec",

--- a/tools/aml-test-tools/Cargo.toml
+++ b/tools/aml-test-tools/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-acpi = { path = "../.." }
+acpi = { path = "../..", public = true }
 log = "0.4"
-pci_types = "0.10.0"
+pci_types = { version = "0.10.0", public = true }
 tempfile = "3.26.0"


### PR DESCRIPTION
```
$ cargo check -Zpublic-dependency
warning: crate `smallvec` from private dependency 'smallvec' is re-exported
 --> src/aml/resource.rs:7:9
  |
7 | pub use smallvec;
  |         ^^^^^^^^
  |
  = note: `#[warn(exported_private_dependencies)]` on by default
note: dependency `smallvec` declared here
  --> Cargo.toml:24:1
   |
24 | smallvec = { version = "1.15.2", default-features = false }
   | --------

warning: type `RawSpinlock` from private dependency 'spinning_top' in public interface
   --> src/aml/mod.rs:106:5
    |
106 |     pub namespace: Spinlock<Namespace>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: dependency `spinning_top` declared here
  --> Cargo.toml:21:1
   |
21 | spinning_top = "0.3.0"
   | ------------

warning: type `Spin` from private dependency 'spinning_top' in public interface
   --> src/aml/mod.rs:106:5
    |
106 |     pub namespace: Spinlock<Namespace>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: dependency `spinning_top` declared here
  --> Cargo.toml:21:1
   |
21 | spinning_top = "0.3.0"
   | ------------

warning: type `RawSpinlock` from private dependency 'spinning_top' in public interface
   --> src/aml/mod.rs:107:5
    |
107 |     pub object_token: Spinlock<ObjectToken>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: dependency `spinning_top` declared here
  --> Cargo.toml:21:1
   |
21 | spinning_top = "0.3.0"
   | ------------

warning: type `Spin` from private dependency 'spinning_top' in public interface
   --> src/aml/mod.rs:107:5
    |
107 |     pub object_token: Spinlock<ObjectToken>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: dependency `spinning_top` declared here
  --> Cargo.toml:21:1
   |
21 | spinning_top = "0.3.0"
   | ------------

warning: type `SmallVec<[u32; 1]>` from private dependency 'smallvec' in public interface
   --> src/aml/resource.rs:343:1
    |
343 | pub type Irqs = smallvec::SmallVec<[u32; 1]>;
    | ^^^^^^^^^^^^^
note: dependency `smallvec` declared here
  --> Cargo.toml:24:1
   |
24 | smallvec = { version = "1.15.2", default-features = false }
   | --------

warning: type `SmallVec<[u32; 1]>` from private dependency 'smallvec' in public interface
   --> src/aml/resource.rs:352:5
    |
352 |     pub irqs: Irqs,
    |     ^^^^^^^^^^^^^^
note: dependency `smallvec` declared here
  --> Cargo.toml:24:1
   |
24 | smallvec = { version = "1.15.2", default-features = false }
   | --------
```

Note that the following warnings remain:

```
warning: type `Mutex<RawSpinlock, Namespace>` from private dependency 'lock_api' in public interface
   --> src/aml/mod.rs:106:5
    |
106 |     pub namespace: Spinlock<Namespace>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(exported_private_dependencies)]` on by default

warning: type `Mutex<RawSpinlock, ObjectToken>` from private dependency 'lock_api' in public interface
   --> src/aml/mod.rs:107:5
    |
107 |     pub object_token: Spinlock<ObjectToken>,
    |     ^^^^^^^^^^
```