### PR TITLE
feat(aml): make `spinning_top`, `byteorder`, and `smallvec` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ edition = "2024"
 bit_field = "0.10.2"
 bitflags = "2.5.0"
 log = "0.4.20"
-spinning_top = "0.3.0"
+spinning_top = { version = "0.3.0", optional = true }
 pci_types = { version = "0.10.0", public = true }
-byteorder = { version = "1.5.0", default-features = false }
-smallvec = { version = "1.15.2", default-features = false }
+byteorder = { version = "1.5.0", optional = true, default-features = false }
+smallvec = { version = "1.15.2", optional = true, default-features = false }
 
 [dev-dependencies]
 aml_test_tools = { path = "tools/aml_test_tools" }
@@ -33,4 +33,9 @@ serial_test = "4.0.1"
 [features]
 default = ["alloc", "aml"]
 alloc = []
-aml = ["alloc"]
+aml = [
+    "alloc",
+    "dep:spinning_top",
+    "dep:byteorder",
+    "dep:smallvec",
+]


### PR DESCRIPTION
```
$ cargo check --no-default-features
warning: unused dependency `byteorder`
  --> Cargo.toml:23:1
   |
23 | byteorder = { version = "1.5.0", default-features = false }
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `cargo::unused_dependencies` is set to `warn` by default
help: consider removing the dependency on `byteorder`
warning: unused dependency `smallvec`
  --> Cargo.toml:24:1
   |
24 | smallvec = { version = "1.15.2", default-features = false, public = true }
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
help: consider removing the dependency on `smallvec`
warning: unused dependency `spinning_top`
  --> Cargo.toml:21:1
   |
21 | spinning_top = { version = "0.3.0", public = true }
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
help: consider removing the dependency on `spinning_top`
```