### PR TITLE
fix: Fix compilation with only the `alloc` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,7 @@ pub enum AcpiError {
 
     Timeout,
 
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "aml")]
     Aml(aml::AmlError),
 
     /// This is emitted to signal that the library does not support the requested behaviour. This


### PR DESCRIPTION
```
$ cargo check --no-default-features --features alloc
error[E0433]: cannot find module or crate `aml` in this scope
   --> src/lib.rs:314:9
    |
314 |     Aml(aml::AmlError),
    |         ^^^ use of unresolved module or unlinked crate `aml`
    |
note: found an item that was configured out
   --> src/lib.rs:57:9
    |
 56 | #[cfg(feature = "aml")]
    |       --------------- the item is gated behind the `aml` feature
 57 | pub mod aml;
    |         ^^^
help: to make use of source file src/aml/mod.rs, use `mod aml` in this file to declare the module
    |
 48 + mod aml;
    |
```