### PR TITLE
ci: Update workflow actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,13 +36,9 @@ jobs:
         submodules: 'recursive'
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        default: true
-        profile: minimal
-        target: ${{ matrix.target }}
-        components: llvm-tools-preview
+      run: |
+        rustup toolchain install --profile minimal --target ${{ matrix.target }} --component llvm-tools nightly
+        rustup default nightly
 
     - name: Build crates
       run: cargo build --target $TARGET $FEATURES
@@ -54,11 +50,9 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        default: true
-        profile: minimal
+      run: |
+        rustup toolchain install --profile minimal nightly
+        rustup default nightly
 
     - name: Install dependencies
       run: sudo apt-get install -y acpica-tools
@@ -76,12 +70,9 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        default: true
-        profile: minimal
-        components: clippy
+      run: |
+        rustup toolchain install --profile minimal --component clippy nightly
+        rustup default nightly
 
     - name: Run clippy
       run: cargo clippy
@@ -96,13 +87,9 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          default: true
-          profile: minimal
-          components: llvm-tools-preview
-          target: x86_64-unknown-none
+        run: |
+          rustup toolchain install --profile minimal --target x86_64-unknown-none --component llvm-tools nightly
+          rustup default nightly
 
       - name: Build no alloc test exe
         working-directory: tools/no_alloc_check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       FEATURES: ${{ matrix.FEATURES }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
 
@@ -50,7 +50,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
     - name: Install Rust
@@ -72,7 +72,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
     - name: Install Rust
@@ -92,7 +92,7 @@ jobs:
   test-no-alloc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
       - name: Install Rust


### PR DESCRIPTION
This PR updates the workflow actions.

This removes the unmaintained and archived [actions-rs/toolchain](https://github.com/actions-rs/toolchain) with the native, preinstalled rustup.
Alternatively, we could adapt [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) or [actions-rust-lang/setup-rust-toolchain](https://github.com/actions-rust-lang/setup-rust-toolchain). They are recommended against by [zizmor's `superfluous-actions`](https://docs.zizmor.sh/audits/#superfluous-actions) lint, unless we need to support custom runners that might not have rustup installed.

Setting `CARGO_INCREMENTAL=0` should speed up CI, since CI does no incremental builds. For details, see https://github.com/dtolnay/rust-toolchain/issues/26.