### PR TITLE
ci: Deny warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
 
 env:
+  CARGO_BUILD_WARNINGS: deny
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
 


### PR DESCRIPTION
[`build.warnings`](https://doc.rust-lang.org/cargo/reference/config.html#buildwarnings) is stable since Rust 1.97.0 and allows controlling rustc and clippy warnings (previously `RUSTFLAGS=-Dwarnings`) as well as rustdoc warnings (previously `RUSTDOCFLAGS=-Dwarnings`) and the new Cargo warnings.

Apparently CI has only failed on errors before, not on warnings.