### PR TITLE
fix(aml): Fix clippy::unnecessary_cast

### DIFF
--- a/src/aml/resource.rs
+++ b/src/aml/resource.rs
@@ -764,7 +764,7 @@ fn gpio_connection_descriptor(bytes: &[u8]) -> Result<Resource, AmlError> {
     let vendor_data_offset = LittleEndian::read_u16(&bytes[19..=20]) as usize;
     let vendor_data_length = LittleEndian::read_u16(&bytes[21..=22]) as usize;
 
-    let pin_count = ((source_name_offset - pin_table_offset) / 2) as usize;
+    let pin_count = (source_name_offset - pin_table_offset) / 2;
     let vendor_data = &bytes[vendor_data_offset..vendor_data_offset + vendor_data_length];
     let source = str::from_utf8(&bytes[source_name_offset..bytes.len() - vendor_data_length - 1])
         .map_err(|_| AmlError::InvalidResourceDescriptor)?;


### PR DESCRIPTION
```console
$ cargo clippy
warning: casting to the same type is unnecessary (`usize` -> `usize`)
   --> src/aml/resource.rs:767:21
    |
767 |     let pin_count = ((source_name_offset - pin_table_offset) / 2) as usize;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `((source_name_offset - pin_table_offset) / 2)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/main/index.html#unnecessary_cast
    = note: `#[warn(clippy::unnecessary_cast)]` on by default

warning: `acpi` (lib) generated 1 warning (run `cargo clippy --fix --lib -p acpi -- ` to apply 1 suggestion)
```


While looking for missed warnings in https://github.com/rust-osdev/acpi/pull/338, I noticed a new one introduced in https://github.com/rust-osdev/acpi/commit/c5267107584e3c3057e7e74ab7d2fdadfb651479. I think this is a good example in favor of https://github.com/rust-osdev/acpi/pull/347. :)